### PR TITLE
Add continuous testing

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,5 +29,5 @@ jobs:
     - name: Test with pytest
       run: |
         # sometimes the scripts hang because the channels can't be closed,
-	# so run under a short timeout
+        # so run under a short timeout
         timeout 15s pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest
+        python -m pip install pytest pytest-cov
     - name: Install Varys
       run: python3 -m pip install -e .
     - name: Test with pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,35 @@
+name: pytest varys
+
+on:
+  push:
+    branches: [ all ]
+  pull_request:
+    branches: [ all ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    services:
+      rabbitmq:
+        image: rabbitmq
+        ports:
+          - 5672:5672
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+    - name: Install Varys
+      run: python3 -m pip install -e .
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,4 +28,6 @@ jobs:
       run: python3 -m pip install -e .
     - name: Test with pytest
       run: |
-        pytest
+        # sometimes the scripts hang because the channels can't be closed,
+	# so run under a short timeout
+        timeout 15s pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,4 +30,4 @@ jobs:
       run: |
         # sometimes the scripts hang because the channels can't be closed,
         # so run under a short timeout
-        timeout 15s pytest
+        timeout 15s pytest --cov-report=term-missing --cov=varys

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,10 +1,6 @@
 name: pytest varys
 
-on:
-  push:
-    branches: [ all ]
-  pull_request:
-    branches: [ all ]
+on: [ push, pull_request ]
 
 jobs:
   build:

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -7,10 +7,11 @@ from varys import varys
 DIR = os.path.dirname(__file__)
 LOG_FILENAME = os.path.join(DIR, 'test.log')
 TMP_HANDLE, TMP_FILENAME = tempfile.mkstemp()
+TEXT = "Hello, world!"
 
 class TestVarys(unittest.TestCase):
 
-    def test_varys(self):
+    def setUp(self):
         config = {
             "version": "0.1",
             "profiles": {
@@ -26,32 +27,49 @@ class TestVarys(unittest.TestCase):
         with open(TMP_FILENAME, 'w') as f:
             json.dump(config, f, ensure_ascii=False)
 
-        text = "Hello, world!"
+        self.v = varys('test', LOG_FILENAME, config_path=TMP_FILENAME)
 
-        v = varys('test', LOG_FILENAME, config_path=TMP_FILENAME)
-
-        self.assertRaises(Exception, v.send, text, 'basic')
-        self.assertRaises(Exception, v.receive, 'basic', block=False)
-
-        v.send(text, 'basic', queue_suffix='q')
-        message = v.receive('basic', queue_suffix='q')
-        self.assertEqual(text, json.loads(message.body))
-
-        message = v.receive('basic', queue_suffix='q', block=False)
-        v.send(text, 'basic', queue_suffix='q')
-        messages = v.receive_batch('basic', queue_suffix='q')
-
-        self.assertRaises(Exception, v.receive_batch, 'batch', block=False)
-
-        channels = v.get_channels()
+    def tearDown(self):
+        channels = self.v.get_channels()
         for key in channels['consumer_channels']:
             print(f"tearing down consumer {key}")
-            v._varys__in_channels[key]["varys_obj"].close_connection()
-            v._varys__in_channels[key]["varys_obj"].stop()
+            self.v._varys__in_channels[key]["varys_obj"].close_connection()
+            self.v._varys__in_channels[key]["varys_obj"].stop()
 
         for key in channels['producer_channels']:
             print(f"tearing down producer {key}")
-            v._varys__out_channels[key]["varys_obj"].stop()
+            self.v._varys__out_channels[key]["varys_obj"].stop()
+
+        os.remove(TMP_FILENAME)
+
+    def test_send_and_receive(self):
+        self.v.send(TEXT, 'basic', queue_suffix='q')
+        message = self.v.receive('basic', queue_suffix='q')
+        self.assertEqual(TEXT, json.loads(message.body))
+
+    # def test_send_and_receive_batch(self):
+    # hangs if in separate test
+        self.v.send(TEXT, 'basic', queue_suffix='q')
+        messages = self.v.receive_batch('basic', queue_suffix='q')
+
+    # def test_receive_no_message(self):
+    # hangs if in separate test
+        self.assertIsNone(self.v.receive('basic', queue_suffix='q', block=False))
+
+    def test_send_no_suffix(self):
+        self.assertRaises(Exception, self.v.send, TEXT, 'basic')
+
+    def test_receive_no_suffix(self):
+        self.assertRaises(Exception, self.v.receive, 'basic', block=False)
+
+    def test_receive_batch_no_suffix(self):
+        self.assertRaises(Exception, self.v.receive_batch, 'basic')
+
+
+class TestVarysConfig(unittest.TestCase):
+
+    def tearDown(self):
+        os.remove(TMP_FILENAME)
 
     def test_config_not_json(self):
         with open(TMP_FILENAME, 'w') as f:
@@ -62,8 +80,6 @@ class TestVarys(unittest.TestCase):
             v = varys('test', LOG_FILENAME, config_path=TMP_FILENAME)
 
         self.assertEqual(cm.exception.code, 11)
-
-        os.remove(TMP_FILENAME)
 
     def test_config_profile_missing(self):
         config = {
@@ -80,8 +96,6 @@ class TestVarys(unittest.TestCase):
             v = varys('test', LOG_FILENAME, config_path=TMP_FILENAME)
             
         self.assertEqual(cm.exception.code, 2)
-
-        os.remove(TMP_FILENAME)
 
     def test_config_profile_incomplete(self):
         config = {
@@ -101,5 +115,3 @@ class TestVarys(unittest.TestCase):
             v = varys('test', LOG_FILENAME, config_path=TMP_FILENAME)
 
         self.assertEqual(cm.exception.code, 11)
-
-        os.remove(TMP_FILENAME)

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -56,8 +56,12 @@ class TestVarys(unittest.TestCase):
     def test_config_not_json(self):
         with open(TMP_FILENAME, 'w') as f:
             f.write("asdf9υ021ζ3;-ö×=()[]{}∇Δοo")
-            
-        self.assertRaises(SystemExit, varys, 'test', LOG_FILENAME, config_path=TMP_FILENAME)
+
+        # use a context manager so we can check SystemExit code
+        with self.assertRaises(SystemExit) as cm:
+            v = varys('test', LOG_FILENAME, config_path=TMP_FILENAME)
+
+        self.assertEqual(cm.exception.code, 11)
 
         os.remove(TMP_FILENAME)
 
@@ -73,7 +77,7 @@ class TestVarys(unittest.TestCase):
             json.dump(config, f, ensure_ascii=False)
             
         with self.assertRaises(SystemExit) as cm:
-            varys('test', LOG_FILENAME, config_path=TMP_FILENAME)
+            v = varys('test', LOG_FILENAME, config_path=TMP_FILENAME)
             
         self.assertEqual(cm.exception.code, 2)
 
@@ -92,7 +96,10 @@ class TestVarys(unittest.TestCase):
 
         with open(TMP_FILENAME, 'w') as f:
             json.dump(config, f, ensure_ascii=False)
-            
-        self.assertRaises(SystemExit, varys, 'test', LOG_FILENAME, config_path=TMP_FILENAME)
+
+        with self.assertRaises(SystemExit) as cm:
+            v = varys('test', LOG_FILENAME, config_path=TMP_FILENAME)
+
+        self.assertEqual(cm.exception.code, 11)
 
         os.remove(TMP_FILENAME)

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -1,0 +1,83 @@
+import unittest
+import tempfile
+import os
+import json
+from varys import varys
+
+DIR = os.path.dirname(__file__)
+LOG_FILENAME = os.path.join(DIR, 'test.log')
+TMP_HANDLE, TMP_FILENAME = tempfile.mkstemp()
+
+class TestVarys(unittest.TestCase):
+
+    def test_varys(self):
+        text = "Hello, world!"
+
+        v = varys('test', LOG_FILENAME, config_path=DIR+'/../test_config.json')
+
+        self.assertRaises(Exception, v.send, text, 'basic')
+        self.assertRaises(Exception, v.receive, 'basic', block=False)
+
+        v.send(text, 'basic', queue_suffix='q')
+        message = v.receive('basic', queue_suffix='q')
+        self.assertEqual(text, json.loads(message.body))
+
+        message = v.receive('basic', queue_suffix='q', block=False)
+        v.send(text, 'basic', queue_suffix='q')
+        messages = v.receive_batch('basic', queue_suffix='q')
+
+        self.assertRaises(Exception, v.receive_batch, 'batch', block=False)
+
+        channels = v.get_channels()
+        for key in channels['consumer_channels']:
+            print(f"tearing down consumer {key}")
+            v._varys__in_channels[key]["varys_obj"].close_connection()
+            v._varys__in_channels[key]["varys_obj"].stop()
+
+        for key in channels['producer_channels']:
+            print(f"tearing down producer {key}")
+            v._varys__out_channels[key]["varys_obj"].stop()
+
+    def test_config_not_json(self):
+        with open(TMP_FILENAME, 'w') as f:
+            f.write("asdf9υ021ζ3;-ö×=()[]{}∇Δοo")
+            
+        self.assertRaises(SystemExit, varys, 'test', LOG_FILENAME, config_path=TMP_FILENAME)
+
+        os.remove(TMP_FILENAME)
+
+    def test_config_profile_missing(self):
+        config = {
+            "version": "0.2",  # bad version prints warning but doesn't raise error
+            "profiles": {
+                "asdfadsf": {}
+            }
+        }
+
+        with open(TMP_FILENAME, 'w') as f:
+            json.dump(config, f, ensure_ascii=False)
+            
+        with self.assertRaises(SystemExit) as cm:
+            varys('test', LOG_FILENAME, config_path=TMP_FILENAME)
+            
+        self.assertEqual(cm.exception.code, 2)
+
+        os.remove(TMP_FILENAME)
+
+    def test_config_profile_incomplete(self):
+        config = {
+            "version": "0.1",
+            "profiles": {
+                "test": {
+                    "username": "username",
+                    "extra": "unnecessary",
+                }
+            }
+        }
+
+        with open(TMP_FILENAME, 'w') as f:
+            json.dump(config, f, ensure_ascii=False)
+            
+        self.assertRaises(SystemExit, varys, 'test', LOG_FILENAME, config_path=TMP_FILENAME)
+
+        os.remove(TMP_FILENAME)

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -11,9 +11,24 @@ TMP_HANDLE, TMP_FILENAME = tempfile.mkstemp()
 class TestVarys(unittest.TestCase):
 
     def test_varys(self):
+        config = {
+            "version": "0.1",
+            "profiles": {
+                "test": {
+                    "username": "guest",
+                    "password": "guest",
+                    "amqp_url": "127.0.0.1",
+                    "port": 5672
+                }
+            }
+        }
+
+        with open(TMP_FILENAME, 'w') as f:
+            json.dump(config, f, ensure_ascii=False)
+
         text = "Hello, world!"
 
-        v = varys('test', LOG_FILENAME, config_path=DIR+'/../test_config.json')
+        v = varys('test', LOG_FILENAME, config_path=TMP_FILENAME)
 
         self.assertRaises(Exception, v.send, text, 'basic')
         self.assertRaises(Exception, v.receive, 'basic', block=False)

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -185,7 +185,7 @@ class producer(Thread):
     def __close_connection(self):
         if self._connection is not None:
             self._log.info("Closing connection")
-            self._channel.close()
+            self._connection.close()
 
     def publish_message(self, message):
         if self._channel is None or not self._channel.is_open:


### PR DESCRIPTION
This sets up a basic test framework that mainly checks Varys can send and receive messages, which covers ~80% of the code base. I eked out a bit more by also covering the failure modes for invalid JSON configuration files.

It isn't obvious how to cover things like failed or interrupted connections, which is much of the remaining code.

The workflow will currently run on all commits and pull requests, which we might want to change later, but the workflow is fast at the moment.