### PR TITLE
Refactor consumer and producer into a single superclass

### DIFF
--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -1,15 +1,11 @@
 import pika
-from pika.exchange_type import ExchangeType
-from threading import Thread
 from functools import partial
 import time
 
 from varys.utils import init_logger, varys_message
+from varys.process import Process
 
-
-class consumer(Thread):
-    exchange_type = ExchangeType.fanout
-
+class consumer(Process):
     def __init__(
         self,
         message_queue,
@@ -23,7 +19,7 @@ class consumer(Thread):
         sleep_interval=10,
         reconnect=True,
     ):
-        Thread.__init__(self)
+        super().__init__()
 
         self._messages = message_queue
 
@@ -31,8 +27,6 @@ class consumer(Thread):
 
         self._should_reconnect = reconnect
         self._reconnect_delay = 10
-        self._connection = None
-        self._channel = None
         self._closing = False
         self._consumer_tag = None
         self._consuming = False
@@ -52,36 +46,24 @@ class consumer(Thread):
             ),
         )
 
-    def __connect(self):
-        return pika.SelectConnection(
-            parameters=self._parameters,
-            on_open_callback=self.__on_connection_open,
-            on_open_error_callback=self.__on_connection_open_error,
-            on_close_callback=self.__on_connection_closed,
-        )
-
-    def __on_connection_open(self, _unused_connection):
-        self._log.info(f"Successfully connected to server")
-        self.__open_channel()
-
-    def __on_connection_open_error(self, _unused_connection, err):
+    def _on_connection_open_error(self, _unused_connection, err):
         self._log.error(f"Failed to connect to server due to error: {err}")
-        self.__reconnect()
+        self._reconnect()
 
-    def __on_connection_closed(self, _unused_connection, reason):
+    def _on_connection_closed(self, _unused_connection, reason):
         self._channel = None
         if self._closing:
             self._connection.ioloop.stop()
         else:
             self._log.warning(f"Connection closed, reconnect necessary: {reason}")
-            self.__reconnect()
+            self._reconnect()
 
-    def __reconnect(self):
+    def _reconnect(self):
         if self._should_reconnect:
             self.stop()
             self._log.warning(f"Reconnecting after {self._reconnect_delay} seconds")
             time.sleep(self._reconnect_delay)
-            self.__connect()
+            self._connect()
         else:
             self._log.info(
                 f"Reconnection was not set to re-connect after disconnection so closing"
@@ -95,47 +77,20 @@ class consumer(Thread):
             self._log.info("Closing connection")
             self._connection.close()
 
-    def __open_channel(self):
-        self._log.info("Creating a new channel")
-        self._connection.channel(on_open_callback=self.__on_channel_open)
-
-    def __on_channel_open(self, channel):
-        self._channel = channel
-        self._log.info("Channel opened")
-        self.__add_on_channel_close_callback()
-        self.__setup_exchange(self._exchange)
-
-    def __add_on_channel_close_callback(self):
-        self._log.info("Adding channel on closed callback")
-        self._channel.add_on_close_callback(self.__on_channel_closed)
-
-    def __on_channel_closed(self, channel, reason):
+    def _on_channel_closed(self, channel, reason):
         self._log.warning(f"Channel {channel} was closed: {reason}")
         self.close_connection()
 
-    def __setup_exchange(self, exchange_name):
-        self._log.info(f"Declaring exchange - {exchange_name}")
-        self._channel.exchange_declare(
-            exchange=exchange_name,
-            exchange_type=self.exchange_type,
-            callback=self.__on_exchange_declareok,
-            durable=True,
-        )
-
-    def __on_exchange_declareok(self, _unused_frame):
-        self._log.info("Exchange successfully declared")
-        self.__setup_queue(self._queue)
-
-    def __setup_queue(self, queue_name):
+    def _setup_queue(self, queue_name):
         self._log.info(f"Declaring queue: {queue_name}")
-        q_callback = partial(self.__on_queue_declareok, queue_name=queue_name)
+        q_callback = partial(self._on_queue_declareok, queue_name=queue_name)
         self._channel.queue_declare(
             queue=queue_name,
             callback=q_callback,
             durable=True,
         )
 
-    def __on_queue_declareok(self, _unused_frame, queue_name):
+    def _on_queue_declareok(self, _unused_frame, queue_name):
         self._log.info(
             f"Binding queue {queue_name} to exchange: {self._exchange} with routing key {self._routing_key}"
         )
@@ -143,77 +98,77 @@ class consumer(Thread):
             queue_name,
             self._exchange,
             routing_key=self._routing_key,
-            callback=self.__on_bindok,
+            callback=self._on_bindok,
         )
 
-    def __on_bindok(self, _unused_frame):
+    def _on_bindok(self, _unused_frame):
         self._log.info("Queue bound successfully")
-        self.__set_qos()
+        self._set_qos()
 
-    def __set_qos(self):
+    def _set_qos(self):
         self._channel.basic_qos(
-            prefetch_count=self._prefetch_count, callback=self.__on_basic_qos_ok
+            prefetch_count=self._prefetch_count, callback=self._on_basic_qos_ok
         )
 
-    def __on_basic_qos_ok(self, _unused_frame):
+    def _on_basic_qos_ok(self, _unused_frame):
         self._log.info(f"QOS set to: {self._prefetch_count}")
-        self.__start_consuming()
+        self._start_consuming()
 
-    def __start_consuming(self):
+    def _start_consuming(self):
         self._log.info("Issuing consumer RPC commands")
-        self.__add_on_cancel_callback()
+        self._add_on_cancel_callback()
         self._consumer_tag = self._channel.basic_consume(
             self._queue,
-            self.__on_message,
+            self._on_message,
         )
         self._consuming = True
 
-    def __add_on_cancel_callback(self):
+    def _add_on_cancel_callback(self):
         self._log.info("Adding consumer cancellation callback")
-        self._channel.add_on_cancel_callback(self.__on_consumer_cancelled)
+        self._channel.add_on_cancel_callback(self._on_consumer_cancelled)
 
-    def __on_consumer_cancelled(self, method_frame):
+    def _on_consumer_cancelled(self, method_frame):
         self._log.info(
             f"Consumer cancelled remotely, now shutting down: {method_frame}"
         )
         if self._channel:
             self._channel.close()
 
-    def __on_message(self, _unused_channel, basic_deliver, properties, body):
+    def _on_message(self, _unused_channel, basic_deliver, properties, body):
         message = varys_message(basic_deliver, properties, body)
         self._log.info(
             f"Received Message: # {message.basic_deliver.delivery_tag} from {message.properties.app_id}, {message.body}"
         )
         self._messages.put(message)
-        self.__acknowledge_message(message.basic_deliver.delivery_tag)
+        self._acknowledge_message(message.basic_deliver.delivery_tag)
 
-    def __acknowledge_message(self, delivery_tag):
+    def _acknowledge_message(self, delivery_tag):
         self._log.info(f"Acknowledging message: {delivery_tag}")
         self._channel.basic_ack(delivery_tag)
 
-    def __stop_consuming(self):
+    def _stop_consuming(self):
         if self._channel:
             self._log.info(
                 "Sending a Basic.Cancel command to central command (stopping message consumption)"
             )
             stop_consume_callback = partial(
-                self.__on_cancelok, consumer_tag=self._consumer_tag
+                self._on_cancelok, consumer_tag=self._consumer_tag
             )
             self._channel.basic_cancel(self._consumer_tag, stop_consume_callback)
 
-    def __on_cancelok(self, _unused_frame, consumer_tag):
+    def _on_cancelok(self, _unused_frame, consumer_tag):
         self._consuming = False
         self._log.info(
             f"Broker acknowledged the cancellation of the consumer: {consumer_tag}"
         )
-        self.__close_channel()
+        self._close_channel()
 
-    def __close_channel(self):
+    def _close_channel(self):
         self._log.info("Closing the channel")
         self._channel.close()
 
     def run(self):
-        self._connection = self.__connect()
+        self._connection = self._connect()
         self._connection.ioloop.start()
 
         return True
@@ -223,7 +178,7 @@ class consumer(Thread):
             self._closing = True
             self._log.info("Stopping as instructed")
             if self._consuming:
-                self.__stop_consuming()
+                self._stop_consuming()
                 self._connection.ioloop.start()
             else:
                 self._connection.ioloop.stop()

--- a/varys/process.py
+++ b/varys/process.py
@@ -1,0 +1,53 @@
+from threading import Thread
+
+import pika
+from pika.exchange_type import ExchangeType
+
+class Process(Thread):
+    def __init__(self):
+        super().__init__()
+
+        self._connection = None
+        self._channel = None
+
+        self._exchange_type = ExchangeType.fanout
+
+    def _connect(self):
+        self._log.info("Connecting to broker")
+        return pika.SelectConnection(
+            self._parameters,
+            on_open_callback=self._on_connection_open,
+            on_open_error_callback=self._on_connection_open_error,
+            on_close_callback=self._on_connection_closed,
+        )
+
+    def _on_connection_open(self, _unused_connection):
+        self._log.info("Successfully opened connection to broker")
+        self._open_channel()
+
+    def _open_channel(self):
+        self._log.info("Creating a new channel")
+        self._connection.channel(on_open_callback=self._on_channel_open)
+
+    def _on_channel_open(self, channel):
+        self._log.info("Channel successfully opened")
+        self._channel = channel
+        self._add_on_channel_close_callback()
+        self._setup_exchange(self._exchange)
+
+    def _add_on_channel_close_callback(self):
+        self._log.info("Adding channel close callback")
+        self._channel.add_on_close_callback(self._on_channel_closed)
+
+    def _setup_exchange(self, exchange_name):
+        self._log.info(f"Declaring exchange: {exchange_name}")
+        self._channel.exchange_declare(
+            exchange=exchange_name,
+            exchange_type=self._exchange_type,
+            callback=self._on_declare_exchangeok,
+            durable=True,
+        )
+
+    def _on_declare_exchangeok(self, _unused_frame):
+        self._log.info("Exchange declared")
+        self._setup_queue(self._queue)

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -1,15 +1,12 @@
 import pika
-from pika.exchange_type import ExchangeType
-
-from threading import Thread
 import time
 import queue
 import json
 
 from varys.utils import init_logger
+from varys.process import Process
 
-
-class producer(Thread):
+class producer(Process):
     def __init__(
         self,
         message_queue,
@@ -22,18 +19,15 @@ class producer(Thread):
         sleep_interval=10,
     ):
         # username, password, queue, ampq_url, port, log_file, exchange="", routing_key="default", sleep_interval=5
-        Thread.__init__(self)
+        super().__init__()
 
         self._log = init_logger(exchange, log_file, log_level)
 
         self._message_queue = message_queue
 
-        self._connection = None
-        self._channel = None
         self._sleep_interval = sleep_interval
 
         self._exchange = exchange
-        self._exchange_type = ExchangeType.fanout
         self._queue = exchange + "." + queue_suffix
         self._routing_key = routing_key
 
@@ -56,29 +50,16 @@ class producer(Thread):
             content_type="json", delivery_mode=2
         )
 
-    def __connect(self):
-        self._log.info("Connecting to broker")
-        return pika.SelectConnection(
-            self._parameters,
-            on_open_callback=self.__on_connection_open,
-            on_open_error_callback=self.__on_connection_open_error,
-            on_close_callback=self.__on_connection_closed,
-        )
-
-    def __on_connection_open(self, _unused_connection):
-        self._log.info("Connection to broker successfully opened")
-        self.__open_channel()
-
-    def __on_connection_open_error(self, _unused_connection, error):
+    def _on_connection_open_error(self, _unused_connection, error):
         self._log.error(
             f"Connection attempt to broker failed, attempting to re-open in {self._sleep_interval} seconds: {error}"
         )
         self._connection.ioloop.stop()
         time.sleep(self._sleep_interval)
-        self._connection = self.__connect()
+        self._connection = self._connect()
         self._connection.ioloop.start()
 
-    def __on_connection_closed(self, _unused_connection, reason):
+    def _on_connection_closed(self, _unused_connection, reason):
         self._channel = None
         if self._stopping:
             self._connection.ioloop.stop()
@@ -88,46 +69,19 @@ class producer(Thread):
             )
             self._connection.ioloop.call_later(10, self._connection.ioloop.start)
 
-    def __open_channel(self):
-        self._log.info("Creating a new channel")
-        self._connection.channel(on_open_callback=self.__on_channel_open)
-
-    def __on_channel_open(self, channel):
-        self._log.info("Channel successfully opened")
-        self._channel = channel
-        self.__add_on_channel_close_callback()
-        self.__setup_exchange(self._exchange)
-
-    def __add_on_channel_close_callback(self):
-        self._log.info("Adding channel close callback")
-        self._channel.add_on_close_callback(self.__on_channel_closed)
-
-    def __on_channel_closed(self, channel, reason):
+    def _on_channel_closed(self, channel, reason):
         self._log.warning(f"Channel {channel} was closed by broker: {reason}")
         self._channel = None
         if not self._stopping:
             self._connection.close()
 
-    def __setup_exchange(self, exchange_name):
-        self._log.info(f"Declaring exchange: {exchange_name}")
-        self._channel.exchange_declare(
-            exchange=exchange_name,
-            exchange_type=self._exchange_type,
-            callback=self.__on_declare_exchangeok,
-            durable=True,
-        )
-
-    def __on_declare_exchangeok(self, _unused_frame):
-        self._log.info("Exchange declared")
-        self.__setup_queue(self._queue)
-
-    def __setup_queue(self, queue):
+    def _setup_queue(self, queue):
         self._log.info(f"Declaring queue {queue}")
         self._channel.queue_declare(
-            queue=queue, durable=True, callback=self.__on_queue_declareok
+            queue=queue, durable=True, callback=self._on_queue_declareok
         )
 
-    def __on_queue_declareok(self, _unused_frame):
+    def _on_queue_declareok(self, _unused_frame):
         self._log.info(
             f"Binding {self._exchange} to {self._queue} with {self._routing_key}"
         )
@@ -135,25 +89,25 @@ class producer(Thread):
             self._queue,
             self._exchange,
             routing_key=self._routing_key,
-            callback=self.__on_bindok,
+            callback=self._on_bindok,
         )
 
-    def __on_bindok(self, _unused_frame):
+    def _on_bindok(self, _unused_frame):
         self._log.info("Queue successfully bound")
-        self.__start_publishing()
+        self._start_publishing()
 
-    def __start_publishing(self):
+    def _start_publishing(self):
         self._log.info(
             "Issuing consumer delivery confirmation commands and sending first message"
         )
-        self.__enable_delivery_confirmations()
-        self.__send_if_queued()
+        self._enable_delivery_confirmations()
+        self._send_if_queued()
 
-    def __enable_delivery_confirmations(self):
+    def _enable_delivery_confirmations(self):
         self._log.info("Issuing Confirm.Select RPC command")
-        self._channel.confirm_delivery(self.__on_delivery_confirmation)
+        self._channel.confirm_delivery(self._on_delivery_confirmation)
 
-    def __on_delivery_confirmation(self, method_frame):
+    def _on_delivery_confirmation(self, method_frame):
         confirmation_type = method_frame.method.NAME.split(".")[1].lower()
         self._log.info(
             f"Received {confirmation_type} for delivery tag: {method_frame.method.delivery_tag}"
@@ -168,21 +122,21 @@ class producer(Thread):
             f"{self._acked} were acked, {self._nacked} were nacked"
         )
 
-    def __send_if_queued(self):
+    def _send_if_queued(self):
         try:
             to_send = self._message_queue.get(block=False)
             self.publish_message(to_send)
         except queue.Empty:
             self._connection.ioloop.call_later(
-                self._sleep_interval, self.__send_if_queued
+                self._sleep_interval, self._send_if_queued
             )
 
-    def __close_channel(self):
+    def _close_channel(self):
         if self._channel is not None:
             self._log.info("Closing the channel")
             self._channel.close()
 
-    def __close_connection(self):
+    def _close_connection(self):
         if self._connection is not None:
             self._log.info("Closing connection")
             self._connection.close()
@@ -210,7 +164,7 @@ class producer(Thread):
         self._message_queue.task_done()
         self._log.info(f"Published message # {self._message_number}")
 
-        self.__send_if_queued()
+        self._send_if_queued()
 
     def run(self):
         while not self._stopping:
@@ -221,7 +175,7 @@ class producer(Thread):
             self._message_number = 0
 
             try:
-                self._connection = self.__connect()
+                self._connection = self._connect()
                 self._connection.ioloop.start()
             except KeyboardInterrupt:
                 self.stop()
@@ -234,5 +188,5 @@ class producer(Thread):
     def stop(self):
         self._log.info("Stopping publisher")
         self._stopping = True
-        self.__close_channel()
-        self.__close_connection()
+        self._close_channel()
+        self._close_connection()


### PR DESCRIPTION
Consumer and producer share some identical code, mostly for handling connections and channels. This PR refactors this common code into a class, currently called `Process`, from which they can inherit. The benefit is a reduction in the total code (currently ~100 fewer lines) and less chance of failing to duplicate features that should be in both consumers and producers.

I'm not bound to the name `Process` and am open to suggestions.

The inheritance was being complicated by the behaviour of class variables with double underscores, so I've set them to single underscores.

There are still places where the producer and consumer do slightly different things, some of which I suspect aren't intentional. But we can always refactor more later.

Feel free to ask questions about relevant sections of code.