### PR TITLE
Start testing Python 3.12 and drop Python 3.7

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     services:
       rabbitmq:
         image: rabbitmq

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     services:
       rabbitmq:
         image: rabbitmq


### PR DESCRIPTION
* Start testing on Python 3.12 (released 2023-10-02)
* Stop testing  on Python 3.7 (reached end-of-life 2023-06-27)

Possibly a bit aggressive to drop 3.7 so I'm not against leaving it in the test matrix for now.