### PR TITLE
Count logger filehandles and refactor

### DIFF
--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -3,6 +3,7 @@ import time
 import tempfile
 import os
 import json
+import logging
 from varys import varys
 
 DIR = os.path.dirname(__file__)
@@ -42,29 +43,36 @@ class TestVarys(unittest.TestCase):
         os.remove(TMP_FILENAME)
         time.sleep(0.1)
 
+        # check that all file handles were dropped
+        logger = logging.getLogger("test_varys")
+        self.assertEqual(len(logger.handlers), 0)
+
     def test_send_and_receive(self):
-        self.v.send(TEXT, "basic_1", queue_suffix="q")
-        message = self.v.receive("basic_1", queue_suffix="q")
+        self.v.send(TEXT, "test_varys", queue_suffix="q")
+        message = self.v.receive("test_varys", queue_suffix="q")
         self.assertEqual(TEXT, json.loads(message.body))
 
+        logger = logging.getLogger("test_varys")
+        self.assertEqual(len(logger.handlers), 1)
+
     def test_send_and_receive_batch(self):
-        self.v.send(TEXT, "basic_2", queue_suffix="q")
-        self.v.send(TEXT, "basic_2", queue_suffix="q")
-        messages = self.v.receive_batch("basic_2", queue_suffix="q")
+        self.v.send(TEXT, "test_varys", queue_suffix="q")
+        self.v.send(TEXT, "test_varys", queue_suffix="q")
+        messages = self.v.receive_batch("test_varys", queue_suffix="q")
         parsed_messages = [json.loads(m.body) for m in messages]
         self.assertListEqual([TEXT, TEXT], parsed_messages)
 
     def test_receive_no_message(self):
-        self.assertIsNone(self.v.receive("basic_3", queue_suffix="q", timeout=1))
+        self.assertIsNone(self.v.receive("test_varys", queue_suffix="q", timeout=1))
 
     def test_send_no_suffix(self):
-        self.assertRaises(Exception, self.v.send, TEXT, "basic_4")
+        self.assertRaises(Exception, self.v.send, TEXT, "test_varys")
 
     def test_receive_no_suffix(self):
-        self.assertRaises(Exception, self.v.receive, "basic_5")
+        self.assertRaises(Exception, self.v.receive, "test_varys")
 
     def test_receive_batch_no_suffix(self):
-        self.assertRaises(Exception, self.v.receive_batch, "basic_6")
+        self.assertRaises(Exception, self.v.receive_batch, "test_varys")
 
 
 class TestVarysConfig(unittest.TestCase):

--- a/varys/__init__.py
+++ b/varys/__init__.py
@@ -1,2 +1,1 @@
 from varys.controller import varys
-from varys.utils import init_logger

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -4,7 +4,7 @@ import time
 
 from pika.exchange_type import ExchangeType
 
-from varys.utils import init_logger, varys_message
+from varys.utils import varys_message
 from varys.process import Process
 
 class consumer(Process):
@@ -184,4 +184,5 @@ class consumer(Process):
                 self._connection.ioloop.start()
             else:
                 self._connection.ioloop.stop()
+
             self._log.info("Stopped as instructed")

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -22,11 +22,9 @@ class consumer(Process):
         reconnect=True,
         exchange_type=ExchangeType.topic
     ):
-        super().__init__()
+        super().__init__(exchange, log_file, log_level)
 
         self._messages = message_queue
-
-        self._log = init_logger(exchange, log_file, log_level)
 
         self._should_reconnect = reconnect
         self._reconnect_delay = 10

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -22,7 +22,7 @@ class consumer(Process):
         reconnect=True,
         exchange_type=ExchangeType.topic
     ):
-        super().__init__(exchange, log_file, log_level)
+        super().__init__(exchange, log_file, log_level, queue_suffix)
 
         self._messages = message_queue
 
@@ -32,9 +32,6 @@ class consumer(Process):
         self._consumer_tag = None
         self._consuming = False
         self._prefetch_count = prefetch_count
-
-        self._exchange = exchange
-        self._queue = exchange + "." + queue_suffix
 
         self._exchange_type = exchange_type
 
@@ -186,3 +183,4 @@ class consumer(Process):
                 self._connection.ioloop.stop()
 
             self._log.info("Stopped as instructed")
+            self._stop_logger()

--- a/varys/process.py
+++ b/varys/process.py
@@ -2,9 +2,13 @@ from threading import Thread
 
 import pika
 
+from varys.utils import init_logger
+
 class Process(Thread):
-    def __init__(self):
+    def __init__(self, exchange, log_file, log_level):
         super().__init__()
+
+        self._log = init_logger(exchange, log_file, log_level)
 
         self._connection = None
         self._channel = None

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -21,14 +21,12 @@ class producer(Process):
         exchange_type=ExchangeType.topic
     ):
         # username, password, queue, ampq_url, port, log_file, exchange="", routing_key="default", sleep_interval=5
-        super().__init__(exchange, log_file, log_level)
+        super().__init__(exchange, log_file, log_level, queue_suffix)
 
         self._message_queue = message_queue
 
         self._sleep_interval = sleep_interval
 
-        self._exchange = exchange
-        self._queue = exchange + "." + queue_suffix
         self._routing_key = routing_key
 
         self._deliveries = None
@@ -192,3 +190,4 @@ class producer(Process):
         self._stopping = True
         self._close_channel()
         self._close_connection()
+        self._stop_logger()

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -5,7 +5,6 @@ import json
 
 from pika.exchange_type import ExchangeType
 
-from varys.utils import init_logger
 from varys.process import Process
 
 class producer(Process):

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -22,9 +22,7 @@ class producer(Process):
         exchange_type=ExchangeType.topic
     ):
         # username, password, queue, ampq_url, port, log_file, exchange="", routing_key="default", sleep_interval=5
-        super().__init__()
-
-        self._log = init_logger(exchange, log_file, log_level)
+        super().__init__(exchange, log_file, log_level)
 
         self._message_queue = message_queue
 

--- a/varys/utils.py
+++ b/varys/utils.py
@@ -9,12 +9,21 @@ def init_logger(name, log_path, log_level):
     log = logging.getLogger(name)
     log.propagate = False
     log.setLevel(log_level)
-    if not (log.hasHandlers()):
+
+    # if the filename is already associated with a handler, increase the count
+    try:
+        handler_filenames = [fh.baseFilename for fh in log.handlers]
+        index = handler_filenames.index(log_path)
+        log.handlers[index].count += 1
+    # otherwise create a new filehandler (with initial count 1)
+    except ValueError:
         logging_fh = logging.FileHandler(log_path)
         logging_fh.setFormatter(
             logging.Formatter("%(name)s\t::%(levelname)s::%(asctime)s::\t%(message)s")
         )
         log.addHandler(logging_fh)
+        log.handlers[-1].count = 1
+
     return log
 
 

--- a/varys/utils.py
+++ b/varys/utils.py
@@ -5,28 +5,6 @@ import json
 import os
 
 
-def init_logger(name, log_path, log_level):
-    log = logging.getLogger(name)
-    log.propagate = False
-    log.setLevel(log_level)
-
-    # if the filename is already associated with a handler, increase the count
-    try:
-        handler_filenames = [fh.baseFilename for fh in log.handlers]
-        index = handler_filenames.index(log_path)
-        log.handlers[index].count += 1
-    # otherwise create a new filehandler (with initial count 1)
-    except ValueError:
-        logging_fh = logging.FileHandler(log_path)
-        logging_fh.setFormatter(
-            logging.Formatter("%(name)s\t::%(levelname)s::%(asctime)s::\t%(message)s")
-        )
-        log.addHandler(logging_fh)
-        log.handlers[-1].count = 1
-
-    return log
-
-
 varys_message = namedtuple("varys_message", "basic_deliver properties body")
 
 


### PR DESCRIPTION
This PR combines several changes to try to more sensibly handle the files for our loggers. The core piece of logic is to attach to each file handle (in the list of handlers) a count of how many times its been requested. As long as this is positive, we'll get output. If it goes back down to zero (by stopping producers or consumers), we drop the file handle.

1. The creation of the loggers is refactored into `Process`, which is the superclass for both `Consumer` and `Producer`. This stops us having to pass logger objects around.
2. A few more `__init__` args are refactored into `Process`, so they're visible to the logger creator.
3. `Consumer` and `Producer` call `Process.stop_logger` in their own `stop` functions. `stop_logger` decrements the file handle counts and drops the file handle if the count reaches zero.
4. There are a few rudimentary tests that the filehandle counts behave correctly.
5. I changed the exchange names in the test to `"varys_test"`, since this give context when inspecting the RabbitMQ status directly. (We might want to stick to other names for whatever reason.)

The hack that makes this work is when we create the `logging.FileHandler` objects and initialise them with a new attribute `count`. Python let's you do this: given an object¹, you can just give it arbitrary extra attributes, as long as they don't collide. An important extra step is that this information is retained when you call `logging.getLogger` again somewhere else.

¹ I've just learned that this [doesn't work out of the box with classes implemented as C objects](https://stackoverflow.com/questions/69947020/why-does-directly-adding-a-new-attribute-to-numpy-arrays-not-work-but-doing-so-b/69947072).