### PR TITLE
Refactor _setup_queue and _on_declareok into Process

### DIFF
--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -1,5 +1,4 @@
 import pika
-from functools import partial
 import time
 
 from pika.exchange_type import ExchangeType
@@ -80,26 +79,6 @@ class consumer(Process):
     def _on_channel_closed(self, channel, reason):
         self._log.warning(f"Channel {channel} was closed: {reason}")
         self.close_connection()
-
-    def _setup_queue(self, queue_name):
-        self._log.info(f"Declaring queue: {queue_name}")
-        q_callback = partial(self._on_queue_declareok, queue_name=queue_name)
-        self._channel.queue_declare(
-            queue=queue_name,
-            callback=q_callback,
-            durable=True,
-        )
-
-    def _on_queue_declareok(self, _unused_frame, queue_name):
-        self._log.info(
-            f"Binding queue {queue_name} to exchange: {self._exchange} with routing key {self._routing_key}"
-        )
-        self._channel.queue_bind(
-            queue_name,
-            self._exchange,
-            routing_key=self._routing_key,
-            callback=self._on_bindok,
-        )
 
     def _on_bindok(self, _unused_frame):
         self._log.info("Queue bound successfully")

--- a/varys/process.py
+++ b/varys/process.py
@@ -1,4 +1,5 @@
 from threading import Thread
+from functools import partial
 import logging
 
 import pika
@@ -98,3 +99,23 @@ class Process(Thread):
     def _on_declare_exchangeok(self, _unused_frame):
         self._log.info("Exchange declared")
         self._setup_queue(self._queue)
+
+    def _setup_queue(self, queue_name):
+        self._log.info(f"Declaring queue: {queue_name}")
+        q_callback = partial(self._on_queue_declareok, queue_name=queue_name)
+        self._channel.queue_declare(
+            queue=queue_name,
+            callback=q_callback,
+            durable=True,
+        )
+
+    def _on_queue_declareok(self, _unused_frame, queue_name):
+        self._log.info(
+            f"Binding queue {queue_name} to exchange: {self._exchange} with routing key {self._routing_key}"
+        )
+        self._channel.queue_bind(
+            queue_name,
+            self._exchange,
+            routing_key=self._routing_key,
+            callback=self._on_bindok,
+        )

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -75,23 +75,6 @@ class producer(Process):
         if not self._stopping:
             self._connection.close()
 
-    def _setup_queue(self, queue):
-        self._log.info(f"Declaring queue {queue}")
-        self._channel.queue_declare(
-            queue=queue, durable=True, callback=self._on_queue_declareok
-        )
-
-    def _on_queue_declareok(self, _unused_frame):
-        self._log.info(
-            f"Binding {self._exchange} to {self._queue} with {self._routing_key}"
-        )
-        self._channel.queue_bind(
-            self._queue,
-            self._exchange,
-            routing_key=self._routing_key,
-            callback=self._on_bindok,
-        )
-
     def _on_bindok(self, _unused_frame):
         self._log.info("Queue successfully bound")
         self._start_publishing()


### PR DESCRIPTION
Uses code that was in `Consumer`, which was slightly more general in that it will pass the `queue_name` argument to `_on_declareok`.