### PR TITLE
Properly parameterise exchange type to be usable

### DIFF
--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -7,6 +7,7 @@ from pika.exchange_type import ExchangeType
 from varys.utils import varys_message
 from varys.process import Process
 
+
 class consumer(Process):
     def __init__(
         self,
@@ -20,7 +21,6 @@ class consumer(Process):
         prefetch_count=5,
         sleep_interval=10,
         reconnect=True,
-        exchange_type=ExchangeType.topic
     ):
         super().__init__(exchange, log_file, log_level, queue_suffix)
 
@@ -32,8 +32,6 @@ class consumer(Process):
         self._consumer_tag = None
         self._consuming = False
         self._prefetch_count = prefetch_count
-
-        self._exchange_type = exchange_type
 
         self._routing_key = routing_key
         self._sleep_interval = sleep_interval

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -18,11 +18,12 @@ class consumer(Process):
         log_file,
         log_level,
         queue_suffix,
+        exchange_type,
         prefetch_count=5,
         sleep_interval=10,
         reconnect=True,
     ):
-        super().__init__(exchange, log_file, log_level, queue_suffix)
+        super().__init__(exchange, log_file, log_level, queue_suffix, exchange_type)
 
         self._messages = message_queue
 

--- a/varys/controller.py
+++ b/varys/controller.py
@@ -31,9 +31,9 @@ class varys:
 
     Methods
     -------
-    send(message, exchange, queue_suffix=False)
+    send(message, exchange, queue_suffix=False, exchange_type="fanout")
         Either send a message to an existing exchange, or create a new exchange connection and send the message to it. queue_suffix must be provided when sending a message to a queue for the first time to instantiate a new connection.
-    receive(exchange, queue_suffix=False, block=True)
+    receive(exchange, queue_suffix=False, block=True, timeout=None, exchange_type="fanout")
         Either receive a message from an existing exchange, or create a new exchange connection and receive a message from it. queue_suffix must be provided when receiving a message from a queue for the first time to instantiate a new connection. block determines whether the receive method should block until a message is received or not.
     receive_batch(exchange, queue_suffix=False)
         Either receive a batch of messages from an existing exchange, or create a new exchange connection and receive a batch of messages from it. queue_suffix must be provided when receiving a message from a queue for the first time to instantiate a new connection.
@@ -68,7 +68,7 @@ class varys:
         self._in_channels = {}
         self._out_channels = {}
 
-    def send(self, message, exchange, queue_suffix=False):
+    def send(self, message, exchange, queue_suffix=False, exchange_type="fanout"):
         """
         Either send a message to an existing exchange, or create a new exchange connection and send the message to it.
         """
@@ -88,12 +88,20 @@ class varys:
                 log_file=self._logfile,
                 log_level=self._log_level,
                 queue_suffix=queue_suffix,
+                exchange_type=exchange_type,
             )
             self._out_channels[exchange]["varys_obj"].start()
 
         self._out_channels[exchange]["queue"].put(message)
 
-    def receive(self, exchange, queue_suffix=False, block=True, timeout=None):
+    def receive(
+        self,
+        exchange,
+        queue_suffix=False,
+        block=True,
+        timeout=None,
+        exchange_type="fanout",
+    ):
         """
         Either receive a message from an existing exchange, or create a new exchange connection and receive a message from it.
         """
@@ -113,6 +121,7 @@ class varys:
                 log_file=self._logfile,
                 log_level=self._log_level,
                 queue_suffix=queue_suffix,
+                exchange_type=exchange_type,
             )
             self._in_channels[exchange]["varys_obj"].start()
 
@@ -128,7 +137,7 @@ class varys:
         except queue.Empty:
             return None
 
-    def receive_batch(self, exchange, queue_suffix=False):
+    def receive_batch(self, exchange, queue_suffix=False, exchange_type="fanout"):
         """
         Either receive all messages available from an existing exchange, or create a new exchange connection and receive all messages available from it.
         """
@@ -148,6 +157,7 @@ class varys:
                 log_file=self._logfile,
                 log_level=self._log_level,
                 queue_suffix=queue_suffix,
+                exchange_type=exchange_type,
             )
             self._in_channels[exchange]["varys_obj"].start()
 

--- a/varys/process.py
+++ b/varys/process.py
@@ -11,7 +11,7 @@ class Process(Thread):
         log_file,
         log_level,
         queue_suffix,
-        exchange_type="fanout",
+        exchange_type,
     ):
         super().__init__()
 

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -3,9 +3,8 @@ import time
 import queue
 import json
 
-from pika.exchange_type import ExchangeType
-
 from varys.process import Process
+
 
 class producer(Process):
     def __init__(
@@ -18,7 +17,6 @@ class producer(Process):
         queue_suffix,
         routing_key="arbitrary_string",
         sleep_interval=10,
-        exchange_type=ExchangeType.topic
     ):
         # username, password, queue, ampq_url, port, log_file, exchange="", routing_key="default", sleep_interval=5
         super().__init__(exchange, log_file, log_level, queue_suffix)
@@ -33,8 +31,6 @@ class producer(Process):
         self._acked = None
         self._nacked = None
         self._message_number = None
-
-        self._exchange_type = exchange_type
 
         self._stopping = False
 

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -15,11 +15,12 @@ class producer(Process):
         log_file,
         log_level,
         queue_suffix,
+        exchange_type,
         routing_key="arbitrary_string",
         sleep_interval=10,
     ):
         # username, password, queue, ampq_url, port, log_file, exchange="", routing_key="default", sleep_interval=5
-        super().__init__(exchange, log_file, log_level, queue_suffix)
+        super().__init__(exchange, log_file, log_level, queue_suffix, exchange_type)
 
         self._message_queue = message_queue
 


### PR DESCRIPTION
Also change the default exchange type back to fanout, topic exchanges are likely to be not how most users expect to interact with the message queues.