### PR TITLE
Implement TLS (SSL) layer

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,7 +37,7 @@ jobs:
         pwd
         # if I do this, the port still seems to be bound in later steps,
         # so perhaps it doesn't matter when we run it
-        # docker run -d -v $(pwd).rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
+        docker run -d -v $(pwd)/.rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -47,7 +47,7 @@ jobs:
     - name: Test with pytest
       run: |
         # maybe we need to run RabbitMQ server in the same step as tests
-        docker run -d -v $(pwd).rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
+        # docker run -d -v $(pwd)/.rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
         # sometimes the scripts hang because the channels can't be closed,
         # so run under a short timeout
         timeout 60s pytest --cov-report=term-missing --cov=varys

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -50,7 +50,7 @@ jobs:
         # docker run -d -v $(pwd)/.rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 -p 5672:5672 rabbitmq
         # sometimes the scripts hang because the channels can't be closed,
         # so run under a short timeout
-        timeout 60s pytest -v --cov-report=term-missing --cov=varys
+        timeout 60s pytest -o log_cli=true --log-cli-level=DEBUG -v --cov-report=term-missing --cov=varys
     - name: 'Upload Logfile'
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,9 +34,6 @@ jobs:
         chmod a+rwx .rabbitmq/*
     - name: Run RabbitMQ server
       run: |
-        pwd
-        # if I do this, the port still seems to be bound in later steps,
-        # so perhaps it doesn't matter when we run it
         docker run -d -v ./.rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 -p 5672:5672 rabbitmq
     - name: Install dependencies
       run: |
@@ -46,11 +43,9 @@ jobs:
       run: python3 -m pip install -e .
     - name: Test with pytest
       run: |
-        # maybe we need to run RabbitMQ server in the same step as tests
-        # docker run -d -v $(pwd)/.rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 -p 5672:5672 rabbitmq
         # sometimes the scripts hang because the channels can't be closed,
         # so run under a short timeout
-        timeout 60s pytest -o log_cli=true --log-cli-level=DEBUG -v --cov-report=term-missing --cov=varys
+        timeout 60s pytest -v --cov-report=term-missing --cov=varys
     - name: 'Upload Logfile'
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Run RabbitMQ server
       run: |
         pwd
-	# if I do this, the port still seems to be bound in later steps,
-	# so perhaps it doesn't matter when we run it
+        # if I do this, the port still seems to be bound in later steps,
+        # so perhaps it doesn't matter when we run it
         # docker run -d -v $(pwd).rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
     - name: Install dependencies
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,6 +44,8 @@ jobs:
       run: python3 -m pip install -e .
     - name: Test with pytest
       run: |
+        # maybe we need to run RabbitMQ server in the same step as tests
+        docker run -d -v $(pwd).rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
         # sometimes the scripts hang because the channels can't be closed,
         # so run under a short timeout
         timeout 60s pytest --cov-report=term-missing --cov=varys

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,7 +35,9 @@ jobs:
     - name: Run RabbitMQ server
       run: |
         pwd
-        docker run -d -v $(pwd).rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
+	# if I do this, the port still seems to be bound in later steps,
+	# so perhaps it doesn't matter when we run it
+        # docker run -d -v $(pwd).rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,7 +37,7 @@ jobs:
         pwd
         # if I do this, the port still seems to be bound in later steps,
         # so perhaps it doesn't matter when we run it
-        docker run -d -v ./rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 -p 5672:5672 rabbitmq
+        docker run -d -v ./.rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 -p 5672:5672 rabbitmq
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,12 +28,14 @@ jobs:
         make verify
         make info
         cd -
-        mv -v tls-gen/basic/result/server*.pem tls-gen/basic/result/ca_certificate.pem .rabbitmq/
+        mv -v tls-gen/basic/result/ca_certificate.pem .rabbitmq/ca_certificate.pem
+        mv -v tls-gen/basic/result/server_*_certificate.pem .rabbitmq/server_localhost_certificate.pem
+        mv -v tls-gen/basic/result/server_*_key.pem .rabbitmq/server_localhost_key.pem
         chmod a+rwx .rabbitmq/*
     - name: Run RabbitMQ server
       run: |
         pwd
-        docker run -v $(pwd).rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
+        docker run -d -v $(pwd).rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -50,7 +50,7 @@ jobs:
         # docker run -d -v $(pwd)/.rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 -p 5672:5672 rabbitmq
         # sometimes the scripts hang because the channels can't be closed,
         # so run under a short timeout
-        timeout 60s pytest --cov-report=term-missing --cov=varys
+        timeout 60s pytest -v --cov-report=term-missing --cov=varys
     - name: 'Upload Logfile'
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,17 +9,29 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-    services:
-      rabbitmq:
-        image: rabbitmq
-        ports:
-          - 5672:5672
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Checkout certificate generator
+      uses: actions/checkout@v3
+      with:
+        repository: rabbitmq/tls-gen
+    - name: Generate certificates
+      run: |
+        cd tls-gen/basic
+        make
+        make verify
+        make info
+        cd -
+        mv -v tls-gen/basic/result/server*.pem tls-gen/basic/result/ca_certificate.pem .rabbitmq/
+        chmod a+rwx .rabbitmq/*
+    - name: Run RabbitMQ server
+      run: |
+        pwd
+        docker run -v $(pwd).rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,7 +37,7 @@ jobs:
         pwd
         # if I do this, the port still seems to be bound in later steps,
         # so perhaps it doesn't matter when we run it
-        docker run -d -v $(pwd)/.rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
+        docker run -d -v ./rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 -p 5672:5672 rabbitmq
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -47,7 +47,7 @@ jobs:
     - name: Test with pytest
       run: |
         # maybe we need to run RabbitMQ server in the same step as tests
-        # docker run -d -v $(pwd)/.rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 rabbitmq
+        # docker run -d -v $(pwd)/.rabbitmq:/.rabbitmq -e RABBITMQ_CONFIG_FILE=/.rabbitmq/rabbitmq.conf -p 5671:5671 -p 5672:5672 rabbitmq
         # sometimes the scripts hang because the channels can't be closed,
         # so run under a short timeout
         timeout 60s pytest --cov-report=term-missing --cov=varys

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -19,8 +19,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: rabbitmq/tls-gen
+        path: tls-gen
     - name: Generate certificates
       run: |
+        ls
         cd tls-gen/basic
         make
         make verify

--- a/.rabbitmq/rabbitmq.conf
+++ b/.rabbitmq/rabbitmq.conf
@@ -1,0 +1,4 @@
+listeners.ssl.default = 5671
+ssl_options.cacertfile           = /.rabbitmq/ca_certificate.pem
+ssl_options.certfile             = /.rabbitmq/server_localhost_certificate.pem
+ssl_options.keyfile              = /.rabbitmq/server_localhost_key.pem

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Varys CI Status](https://github.com/CLIMB-TRE/varys/actions/workflows/pytest.yml/badge.svg)
 
 TODO:
-* Add SSL support
+* Test SSL support with CA-signed certificates
 
 ---
 ### Installation

--- a/example_config.json
+++ b/example_config.json
@@ -5,13 +5,14 @@
             "username": "test_user",
             "password": "test_pass",
             "amqp_url": "192.168.0.1",
-            "port": 5672
+            "use_tls": false
+            "ca_certificate": "/etc/pki/tls/certs/ca-bundle.crt"
         },
         "test_2": {
             "username": "test_user_2",
             "password": "test_pass_2",
             "amqp_url": "192.168.0.1",
-            "port": 5672
+            "use_tls": true
         }
     }
 }

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -23,6 +23,8 @@ class TestVarys(unittest.TestCase):
                     "password": "guest",
                     "amqp_url": "127.0.0.1",
                     "port": 5671,
+                    "use_tls": True,
+                    "ca_certificate": ".rabbitmq/ca_certificate.pem",
                 }
             },
         }

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -67,6 +67,7 @@ class TestVarys(unittest.TestCase):
         logger = logging.getLogger("test_varys")
         self.assertEqual(len(logger.handlers), 1)
 
+    @unittest.skip
     def test_manual_ack(self):
 
         self.v.auto_ack = False
@@ -77,6 +78,7 @@ class TestVarys(unittest.TestCase):
 
         self.v.acknowledge_message(message)
 
+    @unittest.skip
     def test_nack(self):
         self.v.auto_ack = False
 

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -61,6 +61,7 @@ class TestVarys(unittest.TestCase):
 
     def test_send_and_receive(self):
         self.v.send(TEXT, "test_varys", queue_suffix="q")
+        time.sleep(1)
         message = self.v.receive("test_varys", queue_suffix="q")
         self.assertEqual(TEXT, json.loads(message.body))
 

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -40,16 +40,16 @@ class TestVarys(unittest.TestCase):
         # 0.01s seems to be sufficient; 0.1s is just a bit conservative
         time.sleep(0.1)
 
-        credentials = pika.PlainCredentials("guest", "guest")
+        # credentials = pika.PlainCredentials("guest", "guest")
 
-        connection = pika.BlockingConnection(
-            pika.ConnectionParameters("localhost", credentials=credentials)
-        )
-        channel = connection.channel()
+        # connection = pika.BlockingConnection(
+        #     pika.ConnectionParameters("localhost", credentials=credentials)
+        # )
+        # channel = connection.channel()
 
-        channel.queue_delete(queue="test_varys")
+        # channel.queue_delete(queue="test_varys")
 
-        connection.close()
+        # connection.close()
 
         self.v.close()
         os.remove(TMP_FILENAME)

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -40,16 +40,16 @@ class TestVarys(unittest.TestCase):
         # 0.01s seems to be sufficient; 0.1s is just a bit conservative
         time.sleep(0.1)
 
-        # credentials = pika.PlainCredentials("guest", "guest")
+        credentials = pika.PlainCredentials("guest", "guest")
 
-        # connection = pika.BlockingConnection(
-        #     pika.ConnectionParameters("localhost", credentials=credentials)
-        # )
-        # channel = connection.channel()
+        connection = pika.BlockingConnection(
+            pika.ConnectionParameters("localhost", credentials=credentials)
+        )
+        channel = connection.channel()
 
-        # channel.queue_delete(queue="test_varys")
+        channel.queue_delete(queue="test_varys")
 
-        # connection.close()
+        connection.close()
 
         self.v.close()
         os.remove(TMP_FILENAME)

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -107,7 +107,7 @@ class TestVarysTLS(TestVarys):
                 "test": {
                     "username": "guest",
                     "password": "guest",
-                    "amqp_url": "127.0.0.1",
+                    "amqp_url": "localhost",
                     "port": 5671,
                     "use_tls": True,
                     "ca_certificate": ".rabbitmq/ca_certificate.pem",

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -14,25 +14,6 @@ TEXT = "Hello, world!"
 
 
 class TestVarys(unittest.TestCase):
-    def setUp(self):
-        config = {
-            "version": "0.1",
-            "profiles": {
-                "test": {
-                    "username": "guest",
-                    "password": "guest",
-                    "amqp_url": "127.0.0.1",
-                    "port": 5671,
-                    "use_tls": True,
-                    "ca_certificate": ".rabbitmq/ca_certificate.pem",
-                }
-            },
-        }
-
-        with open(TMP_FILENAME, "w") as f:
-            json.dump(config, f, ensure_ascii=False)
-
-        self.v = varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
 
     def tearDown(self):
         # this seems to prevent some hanging
@@ -61,7 +42,7 @@ class TestVarys(unittest.TestCase):
         logger = logging.getLogger("test_varys")
         self.assertEqual(len(logger.handlers), 0)
 
-    def test_send_and_receive(self):
+    def send_and_receive(self):
         self.v.send(TEXT, "test_varys", queue_suffix="q")
         message = self.v.receive("test_varys", queue_suffix="q")
         self.assertEqual(TEXT, json.loads(message.body))
@@ -69,7 +50,7 @@ class TestVarys(unittest.TestCase):
         logger = logging.getLogger("test_varys")
         self.assertEqual(len(logger.handlers), 1)
 
-    def test_manual_ack(self):
+    def manual_ack(self):
 
         self.v.auto_ack = False
 
@@ -79,7 +60,7 @@ class TestVarys(unittest.TestCase):
 
         self.v.acknowledge_message(message)
 
-    def test_nack(self):
+    def nack(self):
         self.v.auto_ack = False
 
         self.v.send(TEXT, "test_varys", queue_suffix="q")
@@ -95,26 +76,120 @@ class TestVarys(unittest.TestCase):
 
         self.assertEqual(message.body, message_2.body)
 
-    def test_send_and_receive_batch(self):
+    def send_and_receive_batch(self):
         self.v.send(TEXT, "test_varys", queue_suffix="q")
         self.v.send(TEXT, "test_varys", queue_suffix="q")
         messages = self.v.receive_batch("test_varys", queue_suffix="q")
         parsed_messages = [json.loads(m.body) for m in messages]
         self.assertListEqual([TEXT, TEXT], parsed_messages)
 
-    def test_receive_no_message(self):
+    def receive_no_message(self):
         self.assertIsNone(
             self.v.receive("test_varys_no_message", queue_suffix="q", timeout=1)
         )
 
-    def test_send_no_suffix(self):
+    def send_no_suffix(self):
         self.assertRaises(Exception, self.v.send, TEXT, "test_varys")
 
-    def test_receive_no_suffix(self):
+    def receive_no_suffix(self):
         self.assertRaises(Exception, self.v.receive, "test_varys")
 
-    def test_receive_batch_no_suffix(self):
+    def receive_batch_no_suffix(self):
         self.assertRaises(Exception, self.v.receive_batch, "test_varys")
+
+
+class TestVarysTLS(TestVarys):
+
+    def setUp(self):
+        config = {
+            "version": "0.1",
+            "profiles": {
+                "test": {
+                    "username": "guest",
+                    "password": "guest",
+                    "amqp_url": "127.0.0.1",
+                    "port": 5671,
+                    "use_tls": True,
+                    "ca_certificate": ".rabbitmq/ca_certificate.pem",
+                }
+            },
+        }
+
+        with open(TMP_FILENAME, "w") as f:
+            json.dump(config, f, ensure_ascii=False)
+
+        self.v = varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
+
+    def test_send_and_receive(self):
+        self.send_and_receive()
+
+    def test_manual_ack(self):
+        self.manual_ack()
+
+    def test_nack(self):
+        self.nack()
+
+    def test_send_and_receive_batch(self):
+        self.send_and_receive_batch()
+
+    def test_receive_no_message(self):
+        self.receive_no_message()
+
+    def test_send_no_suffix(self):
+        self.send_no_suffix()
+
+    def test_receive_no_suffix(self):
+        self.receive_no_suffix()
+
+    def test_receive_batch_no_suffix(self):
+        self.receive_batch_no_suffix()
+
+
+class TestVarysNoTLS(TestVarys):
+
+    def setUp(self):
+        config = {
+            "version": "0.1",
+            "profiles": {
+                "test": {
+                    "username": "guest",
+                    "password": "guest",
+                    "amqp_url": "127.0.0.1",
+                    "port": 5672,
+                    "use_tls": False,
+                    "ca_certificate": "this-value-shouldn't-matter",
+                }
+            },
+        }
+
+        with open(TMP_FILENAME, "w") as f:
+            json.dump(config, f, ensure_ascii=False)
+
+        self.v = varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
+
+    def test_send_and_receive(self):
+        self.send_and_receive()
+
+    def test_manual_ack(self):
+        self.manual_ack()
+
+    def test_nack(self):
+        self.nack()
+
+    def test_send_and_receive_batch(self):
+        self.send_and_receive_batch()
+
+    def test_receive_no_message(self):
+        self.receive_no_message()
+
+    def test_send_no_suffix(self):
+        self.send_no_suffix()
+
+    def test_receive_no_suffix(self):
+        self.receive_no_suffix()
+
+    def test_receive_batch_no_suffix(self):
+        self.receive_batch_no_suffix()
 
 
 class TestVarysConfig(unittest.TestCase):

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -61,14 +61,12 @@ class TestVarys(unittest.TestCase):
 
     def test_send_and_receive(self):
         self.v.send(TEXT, "test_varys", queue_suffix="q")
-        time.sleep(1)
         message = self.v.receive("test_varys", queue_suffix="q")
         self.assertEqual(TEXT, json.loads(message.body))
 
         logger = logging.getLogger("test_varys")
         self.assertEqual(len(logger.handlers), 1)
 
-    @unittest.skip
     def test_manual_ack(self):
 
         self.v.auto_ack = False
@@ -79,7 +77,6 @@ class TestVarys(unittest.TestCase):
 
         self.v.acknowledge_message(message)
 
-    @unittest.skip
     def test_nack(self):
         self.v.auto_ack = False
 

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -22,7 +22,7 @@ class TestVarys(unittest.TestCase):
                     "username": "guest",
                     "password": "guest",
                     "amqp_url": "127.0.0.1",
-                    "port": 5672,
+                    "port": 5671,
                 }
             },
         }

--- a/varys/process.py
+++ b/varys/process.py
@@ -49,9 +49,15 @@ class Process(Thread):
             )
 
         if configuration.use_tls:
-            context = ssl.create_default_context(cafile=configuration.ca_certificate)
+            context = ssl.create_default_context(
+                purpose=ssl.Purpose.SERVER_AUTH,
+                cafile=configuration.ca_certificate,
+            )
+            # default behaviour for Purpose.SERVERAUTH
             context.verify_mode = ssl.CERT_REQUIRED
-            ssl_options = pika.SSLOptions(context, "localhost")
+            context.check_hostname = True
+
+            ssl_options = pika.SSLOptions(context, configuration.ampq_url)
         else:
             ssl_options = None
 

--- a/varys/process.py
+++ b/varys/process.py
@@ -48,8 +48,12 @@ class Process(Thread):
                 "Exchange type must be one of: fanout, topic, direct, headers"
             )
 
-        context = ssl.create_default_context(cafile=".rabbitmq/ca_certificate.pem")
-        context.verify_mode = ssl.CERT_REQUIRED
+        if configuration.use_tls:
+            context = ssl.create_default_context(cafile=configuration.ca_certificate)
+            context.verify_mode = ssl.CERT_REQUIRED
+            ssl_options = pika.SSLOptions(context, "localhost")
+        else:
+            ssl_options = None
 
         self._parameters = pika.ConnectionParameters(
             host=configuration.ampq_url,
@@ -57,7 +61,7 @@ class Process(Thread):
             credentials=pika.PlainCredentials(
                 username=configuration.username, password=configuration.password
             ),
-            ssl_options=pika.SSLOptions(context, "localhost"),
+            ssl_options=ssl_options,
         )
 
     def _setup_logger(self, log_level):

--- a/varys/process.py
+++ b/varys/process.py
@@ -48,7 +48,7 @@ class Process(Thread):
                 "Exchange type must be one of: fanout, topic, direct, headers"
             )
 
-        context = ssl.create_default_context(cafile="/.rabbitmq/ca_certificate.pem")
+        context = ssl.create_default_context(cafile=".rabbitmq/ca_certificate.pem")
         context.verify_mode = ssl.CERT_REQUIRED
 
         self._parameters = pika.ConnectionParameters(

--- a/varys/process.py
+++ b/varys/process.py
@@ -1,5 +1,6 @@
 from threading import Thread
 from functools import partial
+import ssl
 import logging
 
 import pika
@@ -47,12 +48,16 @@ class Process(Thread):
                 "Exchange type must be one of: fanout, topic, direct, headers"
             )
 
+        context = ssl.create_default_context(cafile="/etc/rabbitmq/ssl/ca_certificate.pem")
+        context.verify_mode = ssl.CERT_REQUIRED
+
         self._parameters = pika.ConnectionParameters(
             host=configuration.ampq_url,
             port=configuration.port,
             credentials=pika.PlainCredentials(
                 username=configuration.username, password=configuration.password
             ),
+            ssl_options=pika.SSLOptions(context, "localhost"),
         )
 
     def _setup_logger(self, log_level):

--- a/varys/process.py
+++ b/varys/process.py
@@ -48,7 +48,7 @@ class Process(Thread):
                 "Exchange type must be one of: fanout, topic, direct, headers"
             )
 
-        context = ssl.create_default_context(cafile="/etc/rabbitmq/ssl/ca_certificate.pem")
+        context = ssl.create_default_context(cafile="/.rabbitmq/ca_certificate.pem")
         context.verify_mode = ssl.CERT_REQUIRED
 
         self._parameters = pika.ConnectionParameters(

--- a/varys/utils.py
+++ b/varys/utils.py
@@ -34,6 +34,11 @@ class configurator:
                 self.password = str(profile_dict["password"])
                 self.ampq_url = str(profile_dict["amqp_url"])
                 self.port = int(profile_dict["port"])
+
+                self.use_tls = profile_dict["use_tls"]
+                if self.use_tls:
+                    self.ca_certificate = profile_dict["ca_certificate"]
+
             except KeyError:
                 print(
                     f"Varys configuration JSON does not appear to contain the necessary fields for profile: {profile}",

--- a/varys/utils.py
+++ b/varys/utils.py
@@ -30,14 +30,13 @@ class configurator:
         if profile_dict:
             try:
                 self.profile = profile
-                self.username = str(profile_dict["username"])
-                self.password = str(profile_dict["password"])
-                self.ampq_url = str(profile_dict["amqp_url"])
+                self.username = profile_dict["username"]
+                self.password = profile_dict["password"]
+                self.ampq_url = profile_dict["amqp_url"]
                 self.port = int(profile_dict["port"])
 
                 self.use_tls = profile_dict["use_tls"]
-                if self.use_tls:
-                    self.ca_certificate = profile_dict["ca_certificate"]
+                self.ca_certificate = profile_dict.get("ca_certificate", None)
 
             except KeyError:
                 print(


### PR DESCRIPTION
This PR adds the option of using TLS for the RabbitMQ messages. The fundamental changes in the code are quite small.

1. I added a `use_tls` logical option to the config that, if `true`, means Pika will use port 5671 (instead of 5672) and Python's standard `ssl` library to create an `SSLContext`.
2. I added a `ca_certificate` option to define the path to a Certificate Authority certificate. In production, I don't think this will be necessary, because the `SSLContext` will use the system's standard CA bundle, but we need it for testing.

Most of the changes are to the testing.

1. I created tests for both TLS and non-TLS as best I could by redefining everything into functions that don't start with `test_`, so `pytest` doesn't gather them. Then each function is called in two test cases, one which sets up with TLS and one without.
2. In the CI workflow, the standard RabbitMQ service doesn't offer TLS so I instead generate some test certificates using RabbitMq's [`tls-gen`](https://github.com/rabbitmq/tls-gen) tool and start a RabbitMQ container explicitly. (The paths can be changed later but at least everything we need is there.)

IMO this is worth merging now but at some point we need to test what happens with a real, production-quality certificate that can be checked against standard CA certificates. We want users to be able to connect securely without having to downloading and install certificates, if possible.