### PR TITLE
Use `os.path.abspath` for log file names

### DIFF
--- a/varys/process.py
+++ b/varys/process.py
@@ -1,5 +1,6 @@
 from threading import Thread
 from functools import partial
+from os import path
 import ssl
 import logging
 
@@ -27,7 +28,7 @@ class Process(Thread):
         self._routing_key = routing_key
         self._exchange = exchange
         self._queue = exchange + "." + queue_suffix
-        self._log_file = log_file  # so we know which file handle to drop when we stop
+        self._log_file = path.abspath(log_file)  # so we know which file handle to drop when we stop
         self._setup_logger(log_level)
 
         self._connection = None


### PR DESCRIPTION
I just tripped over a case where Varys tried to release a log file handle using an absolute path but I'd added it using a relative path, so it couldn't find the file handle in the list of handles. This PR changes `Process` to always use the absolute path to `log_file` to remove this ambiguity. 

This should also prevent the (perhaps unlikely) situation where multiple Varys processes refer to the same log file in different ways (e.g. one relative, one absolute) in which case the file would be written to repeatedly because each reference appears to be different.