### PR TITLE
A few fixes to bring Consumer and Producer in line with Pika examples

### DIFF
--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -58,7 +58,8 @@ class consumer(Process):
             self.stop()
             self._log.warning(f"Reconnecting after {self._reconnect_delay} seconds")
             time.sleep(self._reconnect_delay)
-            self._connect()
+            self._connection = self._connect()
+            self._connection.ioloop.start()
         else:
             self._log.info(
                 f"Reconnection was not set to re-connect after disconnection so closing"


### PR DESCRIPTION
While trying to make Varys more robust to the RabbitMQ server being restarted, I found these few places where I think our Producer and Consumer disagree with the Pika example asynchronous [producer (publisher)](https://github.com/pika/pika/blob/main/examples/asynchronous_publisher_example.py) and [consumer](https://github.com/pika/pika/blob/main/examples/asynchronous_consumer_example.py).

I'll make some inline comments on exactly what in Varys corresponds to what in the Pika examples.

These don't stop Varys from crashing when the RabbitMQ server is restarted but I'm pretty sure they're improvements.