### PR TITLE
Use BlockingConnections instead of SelectConnections

### DIFF
--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -34,7 +34,7 @@ class TestVarys(unittest.TestCase):
         )
         channel = connection.channel()
 
-        channel.queue_delete(queue="test_varys")
+        channel.queue_delete(queue="test_varys.q")
 
         connection.close()
 
@@ -79,13 +79,14 @@ class TestVarys(unittest.TestCase):
     def send_and_receive_batch(self):
         self.v.send(TEXT, "test_varys", queue_suffix="q")
         self.v.send(TEXT, "test_varys", queue_suffix="q")
-        messages = self.v.receive_batch("test_varys", queue_suffix="q")
+
+        messages = self.v.receive_batch("test_varys", queue_suffix="q", timeout=1)
         parsed_messages = [json.loads(m.body) for m in messages]
         self.assertListEqual([TEXT, TEXT], parsed_messages)
 
     def receive_no_message(self):
         self.assertIsNone(
-            self.v.receive("test_varys_no_message", queue_suffix="q", timeout=1)
+            self.v.receive("test_varys", queue_suffix="q", timeout=0)
         )
 
     def send_no_suffix(self):
@@ -94,8 +95,8 @@ class TestVarys(unittest.TestCase):
     def receive_no_suffix(self):
         self.assertRaises(Exception, self.v.receive, "test_varys")
 
-    # def receive_batch_no_suffix(self):
-    #     self.assertRaises(Exception, self.v.receive_batch, "test_varys")
+    def receive_batch_no_suffix(self):
+        self.assertRaises(Exception, self.v.receive_batch, "test_varys")
 
 
 class TestVarysTLS(TestVarys):
@@ -129,8 +130,8 @@ class TestVarysTLS(TestVarys):
     def test_nack(self):
         self.nack()
 
-    # def test_send_and_receive_batch(self):
-    #     self.send_and_receive_batch()
+    def test_send_and_receive_batch(self):
+        self.send_and_receive_batch()
 
     def test_receive_no_message(self):
         self.receive_no_message()
@@ -141,8 +142,8 @@ class TestVarysTLS(TestVarys):
     def test_receive_no_suffix(self):
         self.receive_no_suffix()
 
-    # def test_receive_batch_no_suffix(self):
-    #     self.receive_batch_no_suffix()
+    def test_receive_batch_no_suffix(self):
+        self.receive_batch_no_suffix()
 
 
 class TestVarysNoTLS(TestVarys):
@@ -176,8 +177,8 @@ class TestVarysNoTLS(TestVarys):
     def test_nack(self):
         self.nack()
 
-    # def test_send_and_receive_batch(self):
-    #     self.send_and_receive_batch()
+    def test_send_and_receive_batch(self):
+        self.send_and_receive_batch()
 
     def test_receive_no_message(self):
         self.receive_no_message()
@@ -188,8 +189,8 @@ class TestVarysNoTLS(TestVarys):
     def test_receive_no_suffix(self):
         self.receive_no_suffix()
 
-    # def test_receive_batch_no_suffix(self):
-    #     self.receive_batch_no_suffix()
+    def test_receive_batch_no_suffix(self):
+        self.receive_batch_no_suffix()
 
 
 class TestVarysConfig(unittest.TestCase):

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -123,8 +123,8 @@ class TestVarysTLS(TestVarys):
     def test_send_and_receive(self):
         self.send_and_receive()
 
-    # def test_manual_ack(self):
-    #     self.manual_ack()
+    def test_manual_ack(self):
+        self.manual_ack()
 
     def test_nack(self):
         self.nack()
@@ -170,8 +170,8 @@ class TestVarysNoTLS(TestVarys):
     def test_send_and_receive(self):
         self.send_and_receive()
 
-    # def test_manual_ack(self):
-    #     self.manual_ack()
+    def test_manual_ack(self):
+        self.manual_ack()
 
     def test_nack(self):
         self.nack()

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -94,8 +94,8 @@ class TestVarys(unittest.TestCase):
     def receive_no_suffix(self):
         self.assertRaises(Exception, self.v.receive, "test_varys")
 
-    def receive_batch_no_suffix(self):
-        self.assertRaises(Exception, self.v.receive_batch, "test_varys")
+    # def receive_batch_no_suffix(self):
+    #     self.assertRaises(Exception, self.v.receive_batch, "test_varys")
 
 
 class TestVarysTLS(TestVarys):
@@ -126,8 +126,8 @@ class TestVarysTLS(TestVarys):
     # def test_manual_ack(self):
     #     self.manual_ack()
 
-    # def test_nack(self):
-    #     self.nack()
+    def test_nack(self):
+        self.nack()
 
     # def test_send_and_receive_batch(self):
     #     self.send_and_receive_batch()
@@ -135,11 +135,11 @@ class TestVarysTLS(TestVarys):
     def test_receive_no_message(self):
         self.receive_no_message()
 
-    # def test_send_no_suffix(self):
-    #     self.send_no_suffix()
+    def test_send_no_suffix(self):
+        self.send_no_suffix()
 
-    # def test_receive_no_suffix(self):
-    #     self.receive_no_suffix()
+    def test_receive_no_suffix(self):
+        self.receive_no_suffix()
 
     # def test_receive_batch_no_suffix(self):
     #     self.receive_batch_no_suffix()
@@ -173,8 +173,8 @@ class TestVarysNoTLS(TestVarys):
     # def test_manual_ack(self):
     #     self.manual_ack()
 
-    # def test_nack(self):
-    #     self.nack()
+    def test_nack(self):
+        self.nack()
 
     # def test_send_and_receive_batch(self):
     #     self.send_and_receive_batch()
@@ -182,11 +182,11 @@ class TestVarysNoTLS(TestVarys):
     def test_receive_no_message(self):
         self.receive_no_message()
 
-    # def test_send_no_suffix(self):
-    #     self.send_no_suffix()
+    def test_send_no_suffix(self):
+        self.send_no_suffix()
 
-    # def test_receive_no_suffix(self):
-    #     self.receive_no_suffix()
+    def test_receive_no_suffix(self):
+        self.receive_no_suffix()
 
     # def test_receive_batch_no_suffix(self):
     #     self.receive_batch_no_suffix()

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -4,7 +4,7 @@ import tempfile
 import os
 import json
 import logging
-from varys import varys
+from varys import Varys
 import pika
 
 DIR = os.path.dirname(__file__)
@@ -119,7 +119,7 @@ class TestVarysTLS(TestVarys):
         with open(TMP_FILENAME, "w") as f:
             json.dump(config, f, ensure_ascii=False)
 
-        self.v = varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
+        self.v = Varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
 
     def test_send_and_receive(self):
         self.send_and_receive()
@@ -166,7 +166,7 @@ class TestVarysNoTLS(TestVarys):
         with open(TMP_FILENAME, "w") as f:
             json.dump(config, f, ensure_ascii=False)
 
-        self.v = varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
+        self.v = Varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
 
     def test_send_and_receive(self):
         self.send_and_receive()
@@ -203,7 +203,7 @@ class TestVarysConfig(unittest.TestCase):
 
         # use a context manager so we can check SystemExit code
         with self.assertRaises(SystemExit) as cm:
-            v = varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
+            v = Varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
 
         self.assertEqual(cm.exception.code, 11)
 
@@ -217,7 +217,7 @@ class TestVarysConfig(unittest.TestCase):
             json.dump(config, f, ensure_ascii=False)
 
         with self.assertRaises(SystemExit) as cm:
-            v = varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
+            v = Varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
 
         self.assertEqual(cm.exception.code, 2)
 
@@ -236,7 +236,7 @@ class TestVarysConfig(unittest.TestCase):
             json.dump(config, f, ensure_ascii=False)
 
         with self.assertRaises(SystemExit) as cm:
-            v = varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
+            v = Varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
 
         self.assertEqual(cm.exception.code, 11)
 

--- a/tests/test_varys.py
+++ b/tests/test_varys.py
@@ -23,6 +23,10 @@ class TestVarys(unittest.TestCase):
         # 0.01s seems to be sufficient; 0.1s is just a bit conservative
         time.sleep(0.1)
 
+        self.v.close()
+        os.remove(TMP_FILENAME)
+        time.sleep(0.1)
+
         credentials = pika.PlainCredentials("guest", "guest")
 
         connection = pika.BlockingConnection(
@@ -33,10 +37,6 @@ class TestVarys(unittest.TestCase):
         channel.queue_delete(queue="test_varys")
 
         connection.close()
-
-        self.v.close()
-        os.remove(TMP_FILENAME)
-        time.sleep(0.1)
 
         # check that all file handles were dropped
         logger = logging.getLogger("test_varys")
@@ -123,26 +123,26 @@ class TestVarysTLS(TestVarys):
     def test_send_and_receive(self):
         self.send_and_receive()
 
-    def test_manual_ack(self):
-        self.manual_ack()
+    # def test_manual_ack(self):
+    #     self.manual_ack()
 
-    def test_nack(self):
-        self.nack()
+    # def test_nack(self):
+    #     self.nack()
 
-    def test_send_and_receive_batch(self):
-        self.send_and_receive_batch()
+    # def test_send_and_receive_batch(self):
+    #     self.send_and_receive_batch()
 
     def test_receive_no_message(self):
         self.receive_no_message()
 
-    def test_send_no_suffix(self):
-        self.send_no_suffix()
+    # def test_send_no_suffix(self):
+    #     self.send_no_suffix()
 
-    def test_receive_no_suffix(self):
-        self.receive_no_suffix()
+    # def test_receive_no_suffix(self):
+    #     self.receive_no_suffix()
 
-    def test_receive_batch_no_suffix(self):
-        self.receive_batch_no_suffix()
+    # def test_receive_batch_no_suffix(self):
+    #     self.receive_batch_no_suffix()
 
 
 class TestVarysNoTLS(TestVarys):
@@ -170,26 +170,26 @@ class TestVarysNoTLS(TestVarys):
     def test_send_and_receive(self):
         self.send_and_receive()
 
-    def test_manual_ack(self):
-        self.manual_ack()
+    # def test_manual_ack(self):
+    #     self.manual_ack()
 
-    def test_nack(self):
-        self.nack()
+    # def test_nack(self):
+    #     self.nack()
 
-    def test_send_and_receive_batch(self):
-        self.send_and_receive_batch()
+    # def test_send_and_receive_batch(self):
+    #     self.send_and_receive_batch()
 
     def test_receive_no_message(self):
         self.receive_no_message()
 
-    def test_send_no_suffix(self):
-        self.send_no_suffix()
+    # def test_send_no_suffix(self):
+    #     self.send_no_suffix()
 
-    def test_receive_no_suffix(self):
-        self.receive_no_suffix()
+    # def test_receive_no_suffix(self):
+    #     self.receive_no_suffix()
 
-    def test_receive_batch_no_suffix(self):
-        self.receive_batch_no_suffix()
+    # def test_receive_batch_no_suffix(self):
+    #     self.receive_batch_no_suffix()
 
 
 class TestVarysConfig(unittest.TestCase):
@@ -238,3 +238,6 @@ class TestVarysConfig(unittest.TestCase):
             v = varys("test", LOG_FILENAME, config_path=TMP_FILENAME)
 
         self.assertEqual(cm.exception.code, 11)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/varys/__init__.py
+++ b/varys/__init__.py
@@ -1,1 +1,1 @@
-from varys.controller import varys
+from varys.controller import Varys

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -10,25 +10,25 @@ class Consumer(Process):
     def __init__(
         self,
         message_queue,
-        routing_key,
         exchange,
         configuration,
         log_file,
         log_level,
         queue_suffix,
         exchange_type,
+        routing_key="arbitrary_string",
         reconnect_wait=10,
         prefetch_count=5,
     ):
         super().__init__(
             message_queue,
-            routing_key,
             exchange,
             configuration,
             log_file,
             log_level,
             queue_suffix,
             exchange_type,
+            routing_key=routing_key,
             reconnect_wait=reconnect_wait,
         )
 

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -166,20 +166,35 @@ class consumer(Process):
                 else:
                     print("Consumer exception and not stopping")
                     continue
+            finally:
+                break
 
     def stop(self):
         print("Stopping consumer...")
         self._stopping = True
+
         print("- Stopping consuming...")
         self._connection.add_callback_threadsafe(
             self._channel.stop_consuming
         )
-        self._channel.stop_consuming()
-        if self._channel is not None:
-            self._channel.close()
+        # self._channel.stop_consuming()
+
+        print("- Closing channel...")
+        # if self._channel is not None:
+        #     self._channel.close()
+        self._connection.add_callback_threadsafe(
+            self._channel.close
+        )
+
         print("- Closing connection...")
-        if self._connection is not None:
-            self._connection.close()
+        # if self._connection is not None:
+        #     self._connection.close()
+        self._connection.add_callback_threadsafe(
+            self._connection.close
+        )
+        # print("- Closing connection...")
+        # if self._connection is not None:
+        #     self._connection.close()
         print("- Stopping logger...")
         self._stop_logger()
         print("Stopped consumer.")

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -121,7 +121,20 @@ class consumer(Process):
 
     def _acknowledge_message(self, delivery_tag):
         self._log.info(f"Acknowledging message: {delivery_tag}")
-        self._channel.basic_ack(delivery_tag)
+        self._connection.add_callback_threadsafe(
+            functools.partial(self._channel.basic_ack, delivery_tag)
+        )
+
+    def _nack_message(self, delivery_tag, requeue):
+        self._log.info(f"Nacking message: {delivery_tag}")
+        self._connection.add_callback_threadsafe(
+            functools.partial(
+                self._channel.basic_nack,
+                delivery_tag=delivery_tag,
+                multiple=False,
+                requeue=requeue,
+            )
+        )
 
     # def _stop_consuming(self):
     #     if self._channel:

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -2,8 +2,6 @@ import functools
 import pika
 import time
 
-from pika.exchange_type import ExchangeType
-
 from varys.utils import varys_message
 from varys.process import Process
 
@@ -35,8 +33,6 @@ class consumer(Process):
         )
 
         self._closing = False
-        self._consumer_tag = None
-        self._consuming = False
         self._prefetch_count = prefetch_count
 
     def _on_message(self, _unused_channel, basic_deliver, properties, body):

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -6,7 +6,7 @@ from varys.utils import varys_message
 from varys.process import Process
 
 
-class consumer(Process):
+class Consumer(Process):
     def __init__(
         self,
         message_queue,
@@ -17,8 +17,8 @@ class consumer(Process):
         log_level,
         queue_suffix,
         exchange_type,
-        prefetch_count=5,
         reconnect_wait=10,
+        prefetch_count=5,
     ):
         super().__init__(
             message_queue,

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -157,9 +157,10 @@ class consumer(Process):
                 self._channel.queue_declare(queue=self._queue, durable=True)
                 self._channel.queue_bind(queue=self._queue, exchange=self._exchange, routing_key=self._routing_key)
                 self._channel.basic_qos(prefetch_count=1)
-                self._channel.basic_consume(self._queue, self._on_message, auto_ack=True)
+                self._channel.basic_consume(self._queue, self._on_message, auto_ack=False)
                 self._channel.start_consuming()
-            except:
+            except Exception as e:
+                print(e)
                 if self._stopping:
                     print("Consumer exception but stopping")
                     break
@@ -195,6 +196,7 @@ class consumer(Process):
         # print("- Closing connection...")
         # if self._connection is not None:
         #     self._connection.close()
+
         print("- Stopping logger...")
         self._stop_logger()
         print("Stopped consumer.")

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -1,3 +1,4 @@
+import functools
 import pika
 import time
 
@@ -40,75 +41,76 @@ class consumer(Process):
         self._consumer_tag = None
         self._consuming = False
         self._prefetch_count = prefetch_count
+        self._stopping = False
 
-    def _on_connection_open_error(self, _unused_connection, err):
-        self._log.error(f"Failed to connect to server due to error: {err}")
-        self._reconnect()
+    # def _on_connection_open_error(self, _unused_connection, err):
+    #     self._log.error(f"Failed to connect to server due to error: {err}")
+    #     self._reconnect()
 
-    def _on_connection_closed(self, _unused_connection, reason):
-        self._channel = None
-        if self._closing:
-            self._connection.ioloop.stop()
-        else:
-            self._log.warning(f"Connection closed, reconnect necessary: {reason}")
-            self._reconnect()
+    # def _on_connection_closed(self, _unused_connection, reason):
+    #     self._channel = None
+    #     if self._closing:
+    #         self._connection.ioloop.stop()
+    #     else:
+    #         self._log.warning(f"Connection closed, reconnect necessary: {reason}")
+    #         self._reconnect()
 
-    def _reconnect(self):
-        if self._should_reconnect:
-            self.stop()
-            self._log.warning(f"Reconnecting after {self._reconnect_delay} seconds")
-            time.sleep(self._reconnect_delay)
-            self._connection = self._connect()
-            self._connection.ioloop.start()
-        else:
-            self._log.info(
-                f"Reconnection was not set to re-connect after disconnection so closing"
-            )
+    # def _reconnect(self):
+    #     if self._should_reconnect:
+    #         self.stop()
+    #         self._log.warning(f"Reconnecting after {self._reconnect_delay} seconds")
+    #         time.sleep(self._reconnect_delay)
+    #         self._connection = self._connect()
+    #         self._connection.ioloop.start()
+    #     else:
+    #         self._log.info(
+    #             f"Reconnection was not set to re-connect after disconnection so closing"
+    #         )
 
-    def close_connection(self):
-        self._consuming = False
-        if self._connection.is_closing or self._connection.is_closed:
-            self._log.info("Connection is closing or already closed")
-        else:
-            self._log.info("Closing connection")
-            self._connection.close()
+    # def close_connection(self):
+    #     self._consuming = False
+    #     if self._connection.is_closing or self._connection.is_closed:
+    #         self._log.info("Connection is closing or already closed")
+    #     else:
+    #         self._log.info("Closing connection")
+    #         self._connection.close()
 
-    def _on_channel_closed(self, channel, reason):
-        self._log.warning(f"Channel {channel} was closed: {reason}")
-        self.close_connection()
+    # def _on_channel_closed(self, channel, reason):
+    #     self._log.warning(f"Channel {channel} was closed: {reason}")
+    #     self.close_connection()
 
-    def _on_bindok(self, _unused_frame):
-        self._log.info("Queue bound successfully")
-        self._set_qos()
+    # def _on_bindok(self, _unused_frame):
+    #     self._log.info("Queue bound successfully")
+    #     self._set_qos()
 
-    def _set_qos(self):
-        self._channel.basic_qos(
-            prefetch_count=self._prefetch_count, callback=self._on_basic_qos_ok
-        )
+    # def _set_qos(self):
+    #     self._channel.basic_qos(
+    #         prefetch_count=self._prefetch_count, callback=self._on_basic_qos_ok
+    #     )
 
-    def _on_basic_qos_ok(self, _unused_frame):
-        self._log.info(f"QOS set to: {self._prefetch_count}")
-        self._start_consuming()
+    # def _on_basic_qos_ok(self, _unused_frame):
+    #     self._log.info(f"QOS set to: {self._prefetch_count}")
+    #     self._start_consuming()
 
-    def _start_consuming(self):
-        self._log.info("Issuing consumer RPC commands")
-        self._add_on_cancel_callback()
-        self._consumer_tag = self._channel.basic_consume(
-            self._queue,
-            self._on_message,
-        )
-        self._consuming = True
+    # def _start_consuming(self):
+    #     self._log.info("Issuing consumer RPC commands")
+    #     self._add_on_cancel_callback()
+    #     self._consumer_tag = self._channel.basic_consume(
+    #         self._queue,
+    #         self._on_message,
+    #     )
+    #     self._consuming = True
 
-    def _add_on_cancel_callback(self):
-        self._log.info("Adding consumer cancellation callback")
-        self._channel.add_on_cancel_callback(self._on_consumer_cancelled)
+    # def _add_on_cancel_callback(self):
+    #     self._log.info("Adding consumer cancellation callback")
+    #     self._channel.add_on_cancel_callback(self._on_consumer_cancelled)
 
-    def _on_consumer_cancelled(self, method_frame):
-        self._log.info(
-            f"Consumer cancelled remotely, now shutting down: {method_frame}"
-        )
-        if self._channel:
-            self._channel.close()
+    # def _on_consumer_cancelled(self, method_frame):
+    #     self._log.info(
+    #         f"Consumer cancelled remotely, now shutting down: {method_frame}"
+    #     )
+    #     if self._channel:
+    #         self._channel.close()
 
     def _on_message(self, _unused_channel, basic_deliver, properties, body):
         message = varys_message(basic_deliver, properties, body)
@@ -121,42 +123,63 @@ class consumer(Process):
         self._log.info(f"Acknowledging message: {delivery_tag}")
         self._channel.basic_ack(delivery_tag)
 
-    def _stop_consuming(self):
-        if self._channel:
-            self._log.info(
-                "Sending a Basic.Cancel command to central command (stopping message consumption)"
-            )
-            stop_consume_callback = partial(
-                self._on_cancelok, consumer_tag=self._consumer_tag
-            )
-            self._channel.basic_cancel(self._consumer_tag, stop_consume_callback)
+    # def _stop_consuming(self):
+    #     if self._channel:
+    #         self._log.info(
+    #             "Sending a Basic.Cancel command to central command (stopping message consumption)"
+    #         )
+    #         stop_consume_callback = partial(
+    #             self._on_cancelok, consumer_tag=self._consumer_tag
+    #         )
+    #         self._channel.basic_cancel(self._consumer_tag, stop_consume_callback)
 
-    def _on_cancelok(self, _unused_frame, consumer_tag):
-        self._consuming = False
-        self._log.info(
-            f"Broker acknowledged the cancellation of the consumer: {consumer_tag}"
-        )
-        self._close_channel()
+    # def _on_cancelok(self, _unused_frame, consumer_tag):
+    #     self._consuming = False
+    #     self._log.info(
+    #         f"Broker acknowledged the cancellation of the consumer: {consumer_tag}"
+    #     )
+    #     self._close_channel()
 
-    def _close_channel(self):
-        self._log.info("Closing the channel")
-        self._channel.close()
+    # def _close_channel(self):
+    #     self._log.info("Closing the channel")
+    #     self._channel.close()
 
     def run(self):
-        self._connection = self._connect()
-        self._connection.ioloop.start()
-
-        return True
+        while True:
+            try:
+                self._connection = pika.BlockingConnection(self._parameters)
+                self._channel = self._connection.channel()
+                self._channel.exchange_declare(
+                    exchange=self._exchange,
+                    exchange_type=self._exchange_type,
+                    durable=True,
+                )
+                self._channel.queue_declare(queue=self._queue, durable=True)
+                self._channel.queue_bind(queue=self._queue, exchange=self._exchange, routing_key=self._routing_key)
+                self._channel.basic_qos(prefetch_count=1)
+                self._channel.basic_consume(self._queue, self._on_message, auto_ack=True)
+                self._channel.start_consuming()
+            except:
+                if self._stopping:
+                    print("Consumer exception but stopping")
+                    break
+                else:
+                    print("Consumer exception and not stopping")
+                    continue
 
     def stop(self):
-        if not self._closing:
-            self._closing = True
-            self._log.info("Stopping as instructed")
-            if self._consuming:
-                self._stop_consuming()
-                self._connection.ioloop.start()
-            else:
-                self._connection.ioloop.stop()
-
-            self._log.info("Stopped as instructed")
-            self._stop_logger()
+        print("Stopping consumer...")
+        self._stopping = True
+        print("- Stopping consuming...")
+        self._connection.add_callback_threadsafe(
+            self._channel.stop_consuming
+        )
+        self._channel.stop_consuming()
+        if self._channel is not None:
+            self._channel.close()
+        print("- Closing connection...")
+        if self._connection is not None:
+            self._connection.close()
+        print("- Stopping logger...")
+        self._stop_logger()
+        print("Stopped consumer.")

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -43,75 +43,6 @@ class consumer(Process):
         self._prefetch_count = prefetch_count
         self._stopping = False
 
-    # def _on_connection_open_error(self, _unused_connection, err):
-    #     self._log.error(f"Failed to connect to server due to error: {err}")
-    #     self._reconnect()
-
-    # def _on_connection_closed(self, _unused_connection, reason):
-    #     self._channel = None
-    #     if self._closing:
-    #         self._connection.ioloop.stop()
-    #     else:
-    #         self._log.warning(f"Connection closed, reconnect necessary: {reason}")
-    #         self._reconnect()
-
-    # def _reconnect(self):
-    #     if self._should_reconnect:
-    #         self.stop()
-    #         self._log.warning(f"Reconnecting after {self._reconnect_delay} seconds")
-    #         time.sleep(self._reconnect_delay)
-    #         self._connection = self._connect()
-    #         self._connection.ioloop.start()
-    #     else:
-    #         self._log.info(
-    #             f"Reconnection was not set to re-connect after disconnection so closing"
-    #         )
-
-    # def close_connection(self):
-    #     self._consuming = False
-    #     if self._connection.is_closing or self._connection.is_closed:
-    #         self._log.info("Connection is closing or already closed")
-    #     else:
-    #         self._log.info("Closing connection")
-    #         self._connection.close()
-
-    # def _on_channel_closed(self, channel, reason):
-    #     self._log.warning(f"Channel {channel} was closed: {reason}")
-    #     self.close_connection()
-
-    # def _on_bindok(self, _unused_frame):
-    #     self._log.info("Queue bound successfully")
-    #     self._set_qos()
-
-    # def _set_qos(self):
-    #     self._channel.basic_qos(
-    #         prefetch_count=self._prefetch_count, callback=self._on_basic_qos_ok
-    #     )
-
-    # def _on_basic_qos_ok(self, _unused_frame):
-    #     self._log.info(f"QOS set to: {self._prefetch_count}")
-    #     self._start_consuming()
-
-    # def _start_consuming(self):
-    #     self._log.info("Issuing consumer RPC commands")
-    #     self._add_on_cancel_callback()
-    #     self._consumer_tag = self._channel.basic_consume(
-    #         self._queue,
-    #         self._on_message,
-    #     )
-    #     self._consuming = True
-
-    # def _add_on_cancel_callback(self):
-    #     self._log.info("Adding consumer cancellation callback")
-    #     self._channel.add_on_cancel_callback(self._on_consumer_cancelled)
-
-    # def _on_consumer_cancelled(self, method_frame):
-    #     self._log.info(
-    #         f"Consumer cancelled remotely, now shutting down: {method_frame}"
-    #     )
-    #     if self._channel:
-    #         self._channel.close()
-
     def _on_message(self, _unused_channel, basic_deliver, properties, body):
         message = varys_message(basic_deliver, properties, body)
         self._log.info(
@@ -136,27 +67,6 @@ class consumer(Process):
             )
         )
 
-    # def _stop_consuming(self):
-    #     if self._channel:
-    #         self._log.info(
-    #             "Sending a Basic.Cancel command to central command (stopping message consumption)"
-    #         )
-    #         stop_consume_callback = partial(
-    #             self._on_cancelok, consumer_tag=self._consumer_tag
-    #         )
-    #         self._channel.basic_cancel(self._consumer_tag, stop_consume_callback)
-
-    # def _on_cancelok(self, _unused_frame, consumer_tag):
-    #     self._consuming = False
-    #     self._log.info(
-    #         f"Broker acknowledged the cancellation of the consumer: {consumer_tag}"
-    #     )
-    #     self._close_channel()
-
-    # def _close_channel(self):
-    #     self._log.info("Closing the channel")
-    #     self._channel.close()
-
     def run(self):
         while True:
             try:
@@ -173,43 +83,32 @@ class consumer(Process):
                 self._channel.basic_consume(self._queue, self._on_message, auto_ack=False)
                 self._channel.start_consuming()
             except Exception as e:
-                print(e)
                 if self._stopping:
-                    print("Consumer exception but stopping")
+                    self._log.debug("Consumer caught exception while stopping as expected.")
                     break
                 else:
-                    print("Consumer exception and not stopping")
+                    self._log.warn("Consumer caught exception but not told to stop!")
                     continue
 
             break
 
     def stop(self):
-        print("Stopping consumer...")
+        self._log.info("Stopping consumer as instructed...")
         self._stopping = True
 
-        print("- Stopping consuming...")
         self._connection.add_callback_threadsafe(
             self._channel.stop_consuming
         )
-        # self._channel.stop_consuming()
 
-        print("- Closing channel...")
-        # if self._channel is not None:
-        #     self._channel.close()
         self._connection.add_callback_threadsafe(
             self._channel.close
         )
 
-        print("- Closing connection...")
-        # if self._connection is not None:
-        #     self._connection.close()
         self._connection.add_callback_threadsafe(
             self._connection.close
         )
-        # print("- Closing connection...")
-        # if self._connection is not None:
-        #     self._connection.close()
 
-        print("- Stopping logger...")
+        self._log.debug("Stopping consumer logger...")
         self._stop_logger()
-        print("Stopped consumer.")
+
+        self._log.info("Stopped consumer as instructed.")

--- a/varys/consumer.py
+++ b/varys/consumer.py
@@ -180,8 +180,8 @@ class consumer(Process):
                 else:
                     print("Consumer exception and not stopping")
                     continue
-            finally:
-                break
+
+            break
 
     def stop(self):
         print("Stopping consumer...")

--- a/varys/controller.py
+++ b/varys/controller.py
@@ -1,5 +1,3 @@
-import functools
-import json
 import queue
 import os
 import time
@@ -97,18 +95,6 @@ class varys:
             self._out_channels[exchange].start()
             time.sleep(0.1)
 
-        # this probably wants to go back into Producer so we can track number of sends
-        # prod = self._out_channels[exchange]
-        # prod._connection.add_callback_threadsafe(
-        #     functools.partial(
-        #         prod._channel.basic_publish,
-        #         exchange,
-        #         self.routing_key,
-        #         json.dumps(message, ensure_ascii=False),
-        #         prod._message_properties,
-        #     )
-        # )
-        # self._out_channels[exchange]._message_queue.put(message)
         self._out_channels[exchange].publish_message(message, max_attempts=max_attempts)
 
     def receive(self, exchange, queue_suffix=False, timeout=None, exchange_type="fanout"):
@@ -152,6 +138,8 @@ class varys:
         """
         Either receive all messages available from an existing exchange, or create a new exchange connection and receive all messages available from it.
         """
+        if timeout is None:
+            raise ValueError("Timeout cannot be `None` or `receive_batch` would block forever.")
 
         messages = []
         while True:

--- a/varys/controller.py
+++ b/varys/controller.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import queue
 import os
 import time
@@ -52,7 +53,7 @@ class varys:
         log_level="DEBUG",
         config_path=None,
         routing_key="arbitrary_string",
-        auto_acknowledge=True,
+        auto_acknowledge=False,
     ):
         self.profile = profile
 
@@ -94,7 +95,7 @@ class varys:
                 exchange_type=exchange_type,
             )
             self._out_channels[exchange].start()
-            time.sleep(0.5)
+            time.sleep(0.1)
 
         prod = self._out_channels[exchange]
         prod._connection.add_callback_threadsafe(
@@ -102,7 +103,7 @@ class varys:
                 prod._channel.basic_publish,
                 exchange,
                 self.routing_key,
-                message,
+                json.dumps(message, ensure_ascii=False),
                 prod._message_properties,
             )
         )
@@ -137,7 +138,7 @@ class varys:
                 exchange_type=exchange_type,
             )
             self._in_channels[exchange].start()
-            time.sleep(0.5)
+            time.sleep(0.1)
 
         try:
             message = self._in_channels[exchange]._message_queue.get(

--- a/varys/controller.py
+++ b/varys/controller.py
@@ -53,7 +53,7 @@ class varys:
         log_level="DEBUG",
         config_path=None,
         routing_key="arbitrary_string",
-        auto_acknowledge=False,
+        auto_acknowledge=True,
     ):
         self.profile = profile
 
@@ -194,15 +194,6 @@ class varys:
                 break
 
         return messages
-
-    def acknowledge_message(self, message):
-        """
-        Acknowledge a message manually. Not necessary by default where auto_acknowledge is set to True.
-        """
-
-        self._in_channels[message.basic_deliver.exchange]._acknowledge_message(
-            message.basic_deliver.delivery_tag
-        )
 
     def acknowledge_message(self, message):
         """

--- a/varys/controller.py
+++ b/varys/controller.py
@@ -133,6 +133,7 @@ class varys:
                 exchange_type=exchange_type,
             )
             self._in_channels[exchange].start()
+            time.sleep(0.1)
 
         try:
             message = self._in_channels[exchange]._message_queue.get(

--- a/varys/controller.py
+++ b/varys/controller.py
@@ -2,12 +2,12 @@ import queue
 import os
 import time
 
-from varys.consumer import consumer
-from varys.producer import producer
+from varys.consumer import Consumer
+from varys.producer import Producer
 from varys.utils import configurator
 
 
-class varys:
+class Varys:
     """
     A high-level wrapper for the producer and consumer classes used by varys, abstracting away the tedious details.
 
@@ -82,7 +82,7 @@ class varys:
                     "Must provide a queue suffix when sending a message to a queue for the first time"
                 )
 
-            self._out_channels[exchange] = producer(
+            self._out_channels[exchange] = Producer(
                 message_queue=queue.Queue(),
                 routing_key=self.routing_key,
                 exchange=exchange,
@@ -108,7 +108,7 @@ class varys:
                     "Must provide a queue suffix when receiving a message from an exchange for the first time"
                 )
 
-            self._in_channels[exchange] = consumer(
+            self._in_channels[exchange] = Consumer(
                 message_queue=queue.Queue(),
                 routing_key=self.routing_key,
                 exchange=exchange,

--- a/varys/controller.py
+++ b/varys/controller.py
@@ -247,5 +247,5 @@ class varys:
 
         for channel in self._out_channels.values():
             channel.stop()
-            # channel.join()
-            print("Varys stopped a controller.")
+            channel.join()
+            print("Varys stopped a producer.")

--- a/varys/process.py
+++ b/varys/process.py
@@ -19,6 +19,7 @@ class Process(Thread):
         queue_suffix,
         exchange_type,
         sleep_interval=10,
+        reconnect_wait=10,
     ):
         super().__init__()
 
@@ -33,6 +34,8 @@ class Process(Thread):
 
         self._connection = None
         self._channel = None
+        self._stopping = False
+        self._reconnect_wait = reconnect_wait
 
         self._sleep_interval = sleep_interval
 

--- a/varys/process.py
+++ b/varys/process.py
@@ -22,7 +22,7 @@ class Process(Thread):
     ):
         super().__init__()
 
-        Thread.daemon = True
+        # Thread.daemon = True
 
         self._message_queue = message_queue
         self._routing_key = routing_key
@@ -105,70 +105,70 @@ class Process(Thread):
         if self._log.handlers[index].count == 0:
             self._log.handlers.pop(index)
 
-    def _connect(self):
-        self._log.info("Connecting to broker")
-        return pika.SelectConnection(
-            self._parameters,
-            on_open_callback=self._on_connection_open,
-            on_open_error_callback=self._on_connection_open_error,
-            on_close_callback=self._on_connection_closed,
-        )
+    # def _connect(self):
+    #     self._log.info("Connecting to broker")
+    #     return pika.SelectConnection(
+    #         self._parameters,
+    #         on_open_callback=self._on_connection_open,
+    #         on_open_error_callback=self._on_connection_open_error,
+    #         on_close_callback=self._on_connection_closed,
+    #     )
 
-    def _on_connection_open(self, _unused_connection):
-        self._log.info("Successfully opened connection to broker")
-        self._open_channel()
+    # def _on_connection_open(self, _unused_connection):
+    #     self._log.info("Successfully opened connection to broker")
+    #     self._open_channel()
 
-    def _open_channel(self):
-        self._log.info("Creating a new channel")
-        self._connection.channel(on_open_callback=self._on_channel_open)
+    # def _open_channel(self):
+    #     self._log.info("Creating a new channel")
+    #     self._connection.channel(on_open_callback=self._on_channel_open)
 
-    def _on_channel_open(self, channel):
-        self._log.info("Channel successfully opened")
-        self._channel = channel
-        self._add_on_channel_close_callback()
-        self._setup_exchange(self._exchange)
+    # def _on_channel_open(self, channel):
+    #     self._log.info("Channel successfully opened")
+    #     self._channel = channel
+    #     self._add_on_channel_close_callback()
+    #     self._setup_exchange(self._exchange)
 
-    def _add_on_channel_close_callback(self):
-        self._log.info("Adding channel close callback")
-        self._channel.add_on_close_callback(self._on_channel_closed)
+    # def _add_on_channel_close_callback(self):
+    #     self._log.info("Adding channel close callback")
+    #     self._channel.add_on_close_callback(self._on_channel_closed)
 
-    def _setup_exchange(self, exchange_name):
-        self._log.info(f"Declaring exchange: {exchange_name}")
-        self._channel.exchange_declare(
-            exchange=exchange_name,
-            exchange_type=self._exchange_type,
-            callback=self._on_declare_exchangeok,
-            durable=True,
-        )
+    # def _setup_exchange(self, exchange_name):
+    #     self._log.info(f"Declaring exchange: {exchange_name}")
+    #     self._channel.exchange_declare(
+    #         exchange=exchange_name,
+    #         exchange_type=self._exchange_type,
+    #         callback=self._on_declare_exchangeok,
+    #         durable=True,
+    #     )
 
-    def _nack_message(self, delivery_tag, requeue):
-        self._log.info(f"Nacking message: {delivery_tag}")
-        self._channel.basic_nack(
-            delivery_tag=delivery_tag,
-            multiple=False,
-            requeue=requeue,
-        )
+    # def _nack_message(self, delivery_tag, requeue):
+    #     self._log.info(f"Nacking message: {delivery_tag}")
+    #     self._channel.basic_nack(
+    #         delivery_tag=delivery_tag,
+    #         multiple=False,
+    #         requeue=requeue,
+    #     )
 
-    def _on_declare_exchangeok(self, _unused_frame):
-        self._log.info("Exchange declared")
-        self._setup_queue(self._queue)
+    # def _on_declare_exchangeok(self, _unused_frame):
+    #     self._log.info("Exchange declared")
+    #     self._setup_queue(self._queue)
 
-    def _setup_queue(self, queue_name):
-        self._log.info(f"Declaring queue: {queue_name}")
-        q_callback = partial(self._on_queue_declareok, queue_name=queue_name)
-        self._channel.queue_declare(
-            queue=queue_name,
-            callback=q_callback,
-            durable=True,
-        )
+    # def _setup_queue(self, queue_name):
+    #     self._log.info(f"Declaring queue: {queue_name}")
+    #     q_callback = partial(self._on_queue_declareok, queue_name=queue_name)
+    #     self._channel.queue_declare(
+    #         queue=queue_name,
+    #         callback=q_callback,
+    #         durable=True,
+    #     )
 
-    def _on_queue_declareok(self, _unused_frame, queue_name):
-        self._log.info(
-            f"Binding queue {queue_name} to exchange: {self._exchange} with routing key {self._routing_key}"
-        )
-        self._channel.queue_bind(
-            queue_name,
-            self._exchange,
-            routing_key=self._routing_key,
-            callback=self._on_bindok,
-        )
+    # def _on_queue_declareok(self, _unused_frame, queue_name):
+    #     self._log.info(
+    #         f"Binding queue {queue_name} to exchange: {self._exchange} with routing key {self._routing_key}"
+    #     )
+    #     self._channel.queue_bind(
+    #         queue_name,
+    #         self._exchange,
+    #         routing_key=self._routing_key,
+    #         callback=self._on_bindok,
+    #     )

--- a/varys/process.py
+++ b/varys/process.py
@@ -103,7 +103,8 @@ class Process(Thread):
         self._log.handlers[index].count -= 1
 
         if self._log.handlers[index].count == 0:
-            self._log.handlers.pop(index)
+            handler = self._log.handlers.pop(index)
+            handler.close()
 
     # def _connect(self):
     #     self._log.info("Connecting to broker")

--- a/varys/process.py
+++ b/varys/process.py
@@ -18,7 +18,6 @@ class Process(Thread):
         log_level,
         queue_suffix,
         exchange_type,
-        sleep_interval=10,
         reconnect_wait=10,
     ):
         super().__init__()
@@ -36,8 +35,6 @@ class Process(Thread):
         self._channel = None
         self._stopping = False
         self._reconnect_wait = reconnect_wait
-
-        self._sleep_interval = sleep_interval
 
         if exchange_type == "fanout":
             self._exchange_type = pika.exchange_type.ExchangeType.fanout

--- a/varys/process.py
+++ b/varys/process.py
@@ -1,5 +1,4 @@
 from threading import Thread
-from functools import partial
 from os import path
 import ssl
 import logging
@@ -21,8 +20,6 @@ class Process(Thread):
         reconnect_wait=10,
     ):
         super().__init__()
-
-        # Thread.daemon = True
 
         self._message_queue = message_queue
         self._routing_key = routing_key
@@ -105,71 +102,3 @@ class Process(Thread):
         if self._log.handlers[index].count == 0:
             handler = self._log.handlers.pop(index)
             handler.close()
-
-    # def _connect(self):
-    #     self._log.info("Connecting to broker")
-    #     return pika.SelectConnection(
-    #         self._parameters,
-    #         on_open_callback=self._on_connection_open,
-    #         on_open_error_callback=self._on_connection_open_error,
-    #         on_close_callback=self._on_connection_closed,
-    #     )
-
-    # def _on_connection_open(self, _unused_connection):
-    #     self._log.info("Successfully opened connection to broker")
-    #     self._open_channel()
-
-    # def _open_channel(self):
-    #     self._log.info("Creating a new channel")
-    #     self._connection.channel(on_open_callback=self._on_channel_open)
-
-    # def _on_channel_open(self, channel):
-    #     self._log.info("Channel successfully opened")
-    #     self._channel = channel
-    #     self._add_on_channel_close_callback()
-    #     self._setup_exchange(self._exchange)
-
-    # def _add_on_channel_close_callback(self):
-    #     self._log.info("Adding channel close callback")
-    #     self._channel.add_on_close_callback(self._on_channel_closed)
-
-    # def _setup_exchange(self, exchange_name):
-    #     self._log.info(f"Declaring exchange: {exchange_name}")
-    #     self._channel.exchange_declare(
-    #         exchange=exchange_name,
-    #         exchange_type=self._exchange_type,
-    #         callback=self._on_declare_exchangeok,
-    #         durable=True,
-    #     )
-
-    # def _nack_message(self, delivery_tag, requeue):
-    #     self._log.info(f"Nacking message: {delivery_tag}")
-    #     self._channel.basic_nack(
-    #         delivery_tag=delivery_tag,
-    #         multiple=False,
-    #         requeue=requeue,
-    #     )
-
-    # def _on_declare_exchangeok(self, _unused_frame):
-    #     self._log.info("Exchange declared")
-    #     self._setup_queue(self._queue)
-
-    # def _setup_queue(self, queue_name):
-    #     self._log.info(f"Declaring queue: {queue_name}")
-    #     q_callback = partial(self._on_queue_declareok, queue_name=queue_name)
-    #     self._channel.queue_declare(
-    #         queue=queue_name,
-    #         callback=q_callback,
-    #         durable=True,
-    #     )
-
-    # def _on_queue_declareok(self, _unused_frame, queue_name):
-    #     self._log.info(
-    #         f"Binding queue {queue_name} to exchange: {self._exchange} with routing key {self._routing_key}"
-    #     )
-    #     self._channel.queue_bind(
-    #         queue_name,
-    #         self._exchange,
-    #         routing_key=self._routing_key,
-    #         callback=self._on_bindok,
-    #     )

--- a/varys/process.py
+++ b/varys/process.py
@@ -10,13 +10,13 @@ class Process(Thread):
     def __init__(
         self,
         message_queue,
-        routing_key,
         exchange,
         configuration,
         log_file,
         log_level,
         queue_suffix,
         exchange_type,
+        routing_key="arbitrary_string",
         reconnect_wait=10,
     ):
         super().__init__()

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -162,6 +162,8 @@ class producer(Process):
                 else:
                     print("Producer exception and not stopping")
                     continue
+            finally:
+                break
 
     def stop(self):
         print("Stopping producer...")
@@ -170,14 +172,14 @@ class producer(Process):
         print("- Closing channel...")
         # if self._channel is not None:
         #     self._channel.close()
-        # print("- Closing connection...")
+        self._connection.add_callback_threadsafe(
+            self._channel.close
+        )
+        print("- Closing connection...")
         # if self._connection is not None:
         #     self._connection.close()
         self._connection.add_callback_threadsafe(
             self._connection.close
-        )
-        self._connection.add_callback_threadsafe(
-            self._channel.close
         )
         print("- Stopping logger...")
         self._stop_logger()

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -6,7 +6,7 @@ import json
 from varys.process import Process
 
 
-class producer(Process):
+class Producer(Process):
     def __init__(
         self,
         message_queue,

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -21,13 +21,13 @@ class Producer(Process):
     ):
         super().__init__(
             message_queue,
-            routing_key,
             exchange,
             configuration,
             log_file,
             log_level,
             queue_suffix,
             exchange_type,
+            routing_key=routing_key,
             reconnect_wait=reconnect_wait,
         )
 

--- a/varys/utils.py
+++ b/varys/utils.py
@@ -1,8 +1,6 @@
-import logging
 from collections import namedtuple
 import sys
 import json
-import os
 
 
 varys_message = namedtuple("varys_message", "basic_deliver properties body")


### PR DESCRIPTION
This PR replaces the current pika.SelectConnections, which are asynchronous, with BlockingConnections, which are not. Switching away from the chain of callbacks simplifies the Producer and Consumer. Various calls to the threads in which Producers and Consumers are running are usually made via the `Connection.add_callback_threadsafe` function.

The top-level interface is in largely unchanged and the configuration step is completely unaffected.

I dropped a few unused features, including the `consumer_tag`, and tracking the numbers of acked/nacked deliveries.