### PR TITLE
Process data events inside producer thread when stopping

### DIFF
--- a/varys/producer.py
+++ b/varys/producer.py
@@ -105,8 +105,12 @@ class Producer(Process):
             except Exception:
                 self._log.exception("Producer caught exception:")
 
-            if self._stopping or self._reconnect_wait < 0:
+            if self._stopping:
                 self._connection.process_data_events(time_limit=0)
+                break
+            elif self._reconnect_wait < 0:
+                # connection has been broken but we don't want to reconnect
+                # so there's no connection with data events to process
                 break
             else:
                 time.sleep(self._reconnect_wait)

--- a/varys/producer.py
+++ b/varys/producer.py
@@ -106,6 +106,7 @@ class Producer(Process):
                 self._log.exception("Producer caught exception:")
 
             if self._stopping or self._reconnect_wait < 0:
+                self._connection.process_data_events(time_limit=0)
                 break
             else:
                 time.sleep(self._reconnect_wait)


### PR DESCRIPTION
Closes #28.

@BioWilko pointed out that if we close the `Varys` object after sending lots of messages, some of them never make it to the RabbitMQ queues, even though the app itself reports that the messages were sent. I thought the `Producer.stop` function would already catch these with the
```py
        self._connection.add_callback_threadsafe(
            functools.partial(self._connection.process_data_events, time_limit=3)
        )
```
block, but apparently not.

This PR appears to fix the issue by calling `self._connection.process_data_events` inside `Producer.run` on stopping, which is the code that the consumer thread is actually running. I won't pretend to fully understand how the Pika/RabbitMQ threading all works but I think it makes sense that this makes sure we process all the callbacks *inside* the thread. This is different from the block in `stop`, where I think the main Python thread tells the producer thread to process its callbacks.

The block above from `Producer.stop` might no longer be necessary and I'm now actually not even sure it does anything but I've left it in place.